### PR TITLE
Add .clang-format file and reformat all c++ files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,148 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^<ext/.*\.h>'
+    Priority:        2
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Never
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats: 
+  - Language:        Cpp
+    Delimiters:      
+      - cc
+      - CC
+      - cpp
+      - Cpp
+      - CPP
+      - 'c++'
+      - 'C++'
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+  - Language:        TextProto
+    Delimiters:      
+      - pb
+      - PB
+      - proto
+      - PROTO
+    EnclosingFunctions: 
+      - EqualsProto
+      - EquivToProto
+      - PARSE_PARTIAL_TEXT_PROTO
+      - PARSE_TEST_PROTO
+      - PARSE_TEXT_PROTO
+      - ParseTextOrDie
+      - ParseTextProtoOrDie
+    CanonicalDelimiter: ''
+    BasedOnStyle:    google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/interface/BranchManager.h
+++ b/interface/BranchManager.h
@@ -1,56 +1,52 @@
 #ifndef BranchManager_h
 #define BranchManager_h
 
-#include <vector>
+#include <TBranch.h>
+#include <TLorentzVector.h>
+#include <TTree.h>
 #include <string>
 #include <unordered_map>
-#include <TBranch.h>
-#include <TTree.h>
-#include <TLorentzVector.h>
-
+#include <vector>
 
 struct BranchManager {
-  std::vector<TBranch*> branchHolder;
-  std::unordered_map<std::string, TBranch*> specificBranch;
-  TTree* fChain;
+    std::vector<TBranch*> branchHolder;
+    std::unordered_map<std::string, TBranch*> specificBranch;
+    TTree* fChain;
 
-  void SetTree(TTree* fChain_) {
-    fChain = fChain_;
-  } 
+    void SetTree(TTree* fChain_) { fChain = fChain_; }
 
-  template<typename T>
-  void SetBranch(std::string name, T& holder) {
-    branchHolder.push_back({});
-    fChain->SetBranchAddress(name.c_str(), &holder, &branchHolder.back());
-  }
-
-  template<typename T>
-  void SetSpecificBranch(std::string name, T& holder) {
-    if (specificBranch.find(name) != specificBranch.end())
-        specificBranch[name] = {};
-    fChain->SetBranchAddress(name.c_str(), &holder, &specificBranch[name]);
-  }
-
-  void SetEntry(int entry) {
-    for(auto& it: branchHolder) {
-      it->GetEntry(entry);
+    template <typename T>
+    void SetBranch(std::string name, T& holder) {
+        branchHolder.push_back({});
+        fChain->SetBranchAddress(name.c_str(), &holder, &branchHolder.back());
     }
-  }
 
-  void SetSpecificEntry(int entry, std::string name) {
-    specificBranch[name]->GetEntry(entry);
-  }
-  
-  void CleanUp() {
-    branchHolder.clear();
-    specificBranch.clear();
-  }
+    template <typename T>
+    void SetSpecificBranch(std::string name, T& holder) {
+        if (specificBranch.find(name) != specificBranch.end())
+            specificBranch[name] = {};
+        fChain->SetBranchAddress(name.c_str(), &holder, &specificBranch[name]);
+    }
 
-  void CleanSpecificBranch(std::string name) {
-    if (specificBranch.find(name) != specificBranch.end())
-        specificBranch.at(name) = nullptr;
-  }
+    void SetEntry(int entry) {
+        for (auto& it : branchHolder) {
+            it->GetEntry(entry);
+        }
+    }
+
+    void SetSpecificEntry(int entry, std::string name) {
+        specificBranch[name]->GetEntry(entry);
+    }
+
+    void CleanUp() {
+        branchHolder.clear();
+        specificBranch.clear();
+    }
+
+    void CleanSpecificBranch(std::string name) {
+        if (specificBranch.find(name) != specificBranch.end())
+            specificBranch.at(name) = nullptr;
+    }
 };
 
 #endif
-

--- a/interface/Efficiency.h
+++ b/interface/Efficiency.h
@@ -3,49 +3,48 @@
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/ThreeLepSelector.h"
 
-#include <TROOT.h>
 #include <TChain.h>
+#include <TEfficiency.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TEfficiency.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/GoodParticle.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 //#include "TLorentzVector.h"
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> LorentzVector;
-
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
 class Efficiency : public SelectorBase {
-public:
+   public:
     ThreeLepSelector TTTAna;
     ClassDefOverride(Efficiency, 0);
-  
-  
+
     // NanoAOD variables
     // static const unsigned int N_KEEP_MU_E_ = 35;
-    //static const unsigned int N_KEEP_JET_ = 35;
+    // static const unsigned int N_KEEP_JET_ = 35;
     static const unsigned int N_KEEP_GEN_ = 300;
     static const unsigned int N_KEEP_GEN_JET = 35;
-  
+
     //// gen branches ///////////////////////////
     Float_t GenMET_pt;
 
     UInt_t nGenPart;
     Float_t GenPart_pt[N_KEEP_GEN_];
-    Int_t   GenPart_pdgId[N_KEEP_GEN_];
+    Int_t GenPart_pdgId[N_KEEP_GEN_];
     Float_t GenPart_eta[N_KEEP_GEN_];
     Float_t GenPart_phi[N_KEEP_GEN_];
     Float_t GenPart_mass[N_KEEP_GEN_];
     Int_t GenPart_mother[N_KEEP_GEN_];
-  
+
     Float_t GenJet_eta[N_KEEP_GEN_JET];
     Float_t GenJet_phi[N_KEEP_GEN_JET];
     Float_t GenJet_pt[N_KEEP_GEN_JET];
@@ -53,34 +52,38 @@ public:
     Int_t GenJet_partonFlavour[N_KEEP_GEN_JET];
     Int_t GenJet_hadronFlavour[N_KEEP_GEN_JET];
     Float_t GenJet_mass[N_KEEP_GEN_JET];
-   
-  
+
     BranchManager b;
     double weight;
     std::vector<GenPart> Leptons;
     std::vector<GenPart> Jets;
 
-    std::map<int, std::string> lepNameMap = {{PID_MUON, "Muon"}, {PID_ELECTRON, "Elec"}};
+    std::map<int, std::string> lepNameMap = {{PID_MUON, "Muon"},
+                                             {PID_ELECTRON, "Elec"}};
 
     TH2D* Beff_b;
     TH2D* Beff_j;
-   
+
     void clearValues();
-    void fillReco(std::vector<GenPart>& genList, const std::vector<GoodPart>& recoList);
-    
+    void fillReco(std::vector<GenPart>& genList,
+                  const std::vector<GoodPart>& recoList);
+
     // overloaded or necessary functions
-    virtual void    SetBranchesNanoAOD() override;
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    virtual void    SetupNewDirectory() override;
+    virtual void SetBranchesNanoAOD() override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
+    virtual void SetupNewDirectory() override;
     // Readers to access the data (delete the ones you do not need).
-    virtual void    SlaveBegin(TTree *tree) override {return;}
-    virtual void    Init(TTree *tree) override; //{return;}
-    ///ignore
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override {return;}
-    virtual void    SetBranchesUWVV() override {return;}
+    virtual void SlaveBegin(TTree* tree) override { return; }
+    virtual void Init(TTree* tree) override;  //{return;}
+    /// ignore
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override {
+        return;
+    }
+    virtual void SetBranchesUWVV() override { return; }
 };
 
-
 #endif
-

--- a/interface/FakeRateSelector.h
+++ b/interface/FakeRateSelector.h
@@ -1,21 +1,20 @@
 #ifndef FakeRateSelector_h
 #define FakeRateSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TROOT.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
-#include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
 #include <vector>
+#include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
 
-
-class FakeRateSelector : public WZSelectorBase { 
-public :
+class FakeRateSelector : public WZSelectorBase {
+   public:
     TH2D* passingTight2D_;
     TH1D* passingTight1DPt_;
     TH1D* passingTight1DEta_;
@@ -29,16 +28,17 @@ public :
     Float_t type1_pfMETEt;
     UInt_t nCBVIDVetoElec;
     UInt_t nWZLooseMuon;
-    
+
     TBranch* b_type1_pfMETEt;
     TBranch* b_nCBVIDVetoElec;
     TBranch* b_nWZLooseMuon;
 
     // Readers to access the data (delete the ones you do not need).
-    virtual void    SetupNewDirectory() override;
-    virtual void    FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void SetupNewDirectory() override;
+    virtual void FillHistograms(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
 
-    ClassDefOverride(FakeRateSelector,0);
+    ClassDefOverride(FakeRateSelector, 0);
 };
 
 #endif

--- a/interface/FourTopScales.h
+++ b/interface/FourTopScales.h
@@ -2,86 +2,86 @@
 #define _FOURTOPSCALES_H_
 
 float getTruePUw(int nvtx) {
-    if (nvtx>=0.000000 && nvtx<1.000000) return 0.366077;
-    if (nvtx>=1.000000 && nvtx<2.000000) return 0.893925;
-    if (nvtx>=2.000000 && nvtx<3.000000) return 1.197716;
-    if (nvtx>=3.000000 && nvtx<4.000000) return 0.962699;
-    if (nvtx>=4.000000 && nvtx<5.000000) return 1.120976;
-    if (nvtx>=5.000000 && nvtx<6.000000) return 1.164859;
-    if (nvtx>=6.000000 && nvtx<7.000000) return 0.795599;
-    if (nvtx>=7.000000 && nvtx<8.000000) return 0.495824;
-    if (nvtx>=8.000000 && nvtx<9.000000) return 0.742182;
-    if (nvtx>=9.000000 && nvtx<10.000000) return 0.878856;
-    if (nvtx>=10.000000 && nvtx<11.000000) return 0.964232;
-    if (nvtx>=11.000000 && nvtx<12.000000) return 1.072499;
-    if (nvtx>=12.000000 && nvtx<13.000000) return 1.125335;
-    if (nvtx>=13.000000 && nvtx<14.000000) return 1.176027;
-    if (nvtx>=14.000000 && nvtx<15.000000) return 1.202083;
-    if (nvtx>=15.000000 && nvtx<16.000000) return 1.207643;
-    if (nvtx>=16.000000 && nvtx<17.000000) return 1.200176;
-    if (nvtx>=17.000000 && nvtx<18.000000) return 1.182682;
-    if (nvtx>=18.000000 && nvtx<19.000000) return 1.143998;
-    if (nvtx>=19.000000 && nvtx<20.000000) return 1.096632;
-    if (nvtx>=20.000000 && nvtx<21.000000) return 1.065602;
-    if (nvtx>=21.000000 && nvtx<22.000000) return 1.051166;
-    if (nvtx>=22.000000 && nvtx<23.000000) return 1.051600;
-    if (nvtx>=23.000000 && nvtx<24.000000) return 1.050630;
-    if (nvtx>=24.000000 && nvtx<25.000000) return 1.049862;
-    if (nvtx>=25.000000 && nvtx<26.000000) return 1.058173;
-    if (nvtx>=26.000000 && nvtx<27.000000) return 1.072155;
-    if (nvtx>=27.000000 && nvtx<28.000000) return 1.083030;
-    if (nvtx>=28.000000 && nvtx<29.000000) return 1.095693;
-    if (nvtx>=29.000000 && nvtx<30.000000) return 1.107871;
-    if (nvtx>=30.000000 && nvtx<31.000000) return 1.094621;
-    if (nvtx>=31.000000 && nvtx<32.000000) return 1.082620;
-    if (nvtx>=32.000000 && nvtx<33.000000) return 1.041247;
-    if (nvtx>=33.000000 && nvtx<34.000000) return 0.985752;
-    if (nvtx>=34.000000 && nvtx<35.000000) return 0.910807;
-    if (nvtx>=35.000000 && nvtx<36.000000) return 0.820923;
-    if (nvtx>=36.000000 && nvtx<37.000000) return 0.716787;
-    if (nvtx>=37.000000 && nvtx<38.000000) return 0.610013;
-    if (nvtx>=38.000000 && nvtx<39.000000) return 0.503118;
-    if (nvtx>=39.000000 && nvtx<40.000000) return 0.404841;
-    if (nvtx>=40.000000 && nvtx<41.000000) return 0.309195;
-    if (nvtx>=41.000000 && nvtx<42.000000) return 0.227920;
-    if (nvtx>=42.000000 && nvtx<43.000000) return 0.163690;
-    if (nvtx>=43.000000 && nvtx<44.000000) return 0.113180;
-    if (nvtx>=44.000000 && nvtx<45.000000) return 0.077300;
-    if (nvtx>=45.000000 && nvtx<46.000000) return 0.050922;
-    if (nvtx>=46.000000 && nvtx<47.000000) return 0.031894;
-    if (nvtx>=47.000000 && nvtx<48.000000) return 0.020094;
-    if (nvtx>=48.000000 && nvtx<49.000000) return 0.012263;
-    if (nvtx>=49.000000 && nvtx<50.000000) return 0.007426;
-    if (nvtx>=50.000000 && nvtx<51.000000) return 0.004380;
-    if (nvtx>=51.000000 && nvtx<52.000000) return 0.002608;
-    if (nvtx>=52.000000 && nvtx<53.000000) return 0.001566;
-    if (nvtx>=53.000000 && nvtx<54.000000) return 0.000971;
-    if (nvtx>=54.000000 && nvtx<55.000000) return 0.000729;
-    if (nvtx>=55.000000 && nvtx<56.000000) return 0.000673;
-    if (nvtx>=56.000000 && nvtx<57.000000) return 0.000730;
-    if (nvtx>=57.000000 && nvtx<58.000000) return 0.000949;
-    if (nvtx>=58.000000 && nvtx<59.000000) return 0.001355;
-    if (nvtx>=59.000000 && nvtx<60.000000) return 0.001894;
-    if (nvtx>=60.000000 && nvtx<61.000000) return 0.003082;
-    if (nvtx>=61.000000 && nvtx<62.000000) return 0.004097;
-    if (nvtx>=62.000000 && nvtx<63.000000) return 0.004874;
-    if (nvtx>=63.000000 && nvtx<64.000000) return 0.005256;
-    if (nvtx>=64.000000 && nvtx<65.000000) return 0.005785;
-    if (nvtx>=65.000000 && nvtx<66.000000) return 0.005515;
-    if (nvtx>=66.000000 && nvtx<67.000000) return 0.005000;
-    if (nvtx>=67.000000 && nvtx<68.000000) return 0.004410;
-    if (nvtx>=68.000000 && nvtx<69.000000) return 0.004012;
-    if (nvtx>=69.000000 && nvtx<70.000000) return 0.003548;
-    if (nvtx>=70.000000 && nvtx<71.000000) return 0.003108;
-    if (nvtx>=71.000000 && nvtx<72.000000) return 0.002702;
-    if (nvtx>=72.000000 && nvtx<73.000000) return 0.002337;
-    if (nvtx>=73.000000 && nvtx<74.000000) return 0.002025;
-    if (nvtx>=74.000000 && nvtx<75.000000) return 0.001723;
-    if (nvtx>=75.000000 && nvtx<76.000000) return 0.000000;
-    if (nvtx>=76.000000 && nvtx<77.000000) return 0.000000;
-    if (nvtx>=77.000000 && nvtx<78.000000) return 0.000000;
-    if (nvtx>=78.000000 && nvtx<79.000000) return 0.000000;
-    if (nvtx>=79.000000 && nvtx<80.000000) return 0.000000;
+    if (nvtx >= 0.000000 && nvtx < 1.000000) return 0.366077;
+    if (nvtx >= 1.000000 && nvtx < 2.000000) return 0.893925;
+    if (nvtx >= 2.000000 && nvtx < 3.000000) return 1.197716;
+    if (nvtx >= 3.000000 && nvtx < 4.000000) return 0.962699;
+    if (nvtx >= 4.000000 && nvtx < 5.000000) return 1.120976;
+    if (nvtx >= 5.000000 && nvtx < 6.000000) return 1.164859;
+    if (nvtx >= 6.000000 && nvtx < 7.000000) return 0.795599;
+    if (nvtx >= 7.000000 && nvtx < 8.000000) return 0.495824;
+    if (nvtx >= 8.000000 && nvtx < 9.000000) return 0.742182;
+    if (nvtx >= 9.000000 && nvtx < 10.000000) return 0.878856;
+    if (nvtx >= 10.000000 && nvtx < 11.000000) return 0.964232;
+    if (nvtx >= 11.000000 && nvtx < 12.000000) return 1.072499;
+    if (nvtx >= 12.000000 && nvtx < 13.000000) return 1.125335;
+    if (nvtx >= 13.000000 && nvtx < 14.000000) return 1.176027;
+    if (nvtx >= 14.000000 && nvtx < 15.000000) return 1.202083;
+    if (nvtx >= 15.000000 && nvtx < 16.000000) return 1.207643;
+    if (nvtx >= 16.000000 && nvtx < 17.000000) return 1.200176;
+    if (nvtx >= 17.000000 && nvtx < 18.000000) return 1.182682;
+    if (nvtx >= 18.000000 && nvtx < 19.000000) return 1.143998;
+    if (nvtx >= 19.000000 && nvtx < 20.000000) return 1.096632;
+    if (nvtx >= 20.000000 && nvtx < 21.000000) return 1.065602;
+    if (nvtx >= 21.000000 && nvtx < 22.000000) return 1.051166;
+    if (nvtx >= 22.000000 && nvtx < 23.000000) return 1.051600;
+    if (nvtx >= 23.000000 && nvtx < 24.000000) return 1.050630;
+    if (nvtx >= 24.000000 && nvtx < 25.000000) return 1.049862;
+    if (nvtx >= 25.000000 && nvtx < 26.000000) return 1.058173;
+    if (nvtx >= 26.000000 && nvtx < 27.000000) return 1.072155;
+    if (nvtx >= 27.000000 && nvtx < 28.000000) return 1.083030;
+    if (nvtx >= 28.000000 && nvtx < 29.000000) return 1.095693;
+    if (nvtx >= 29.000000 && nvtx < 30.000000) return 1.107871;
+    if (nvtx >= 30.000000 && nvtx < 31.000000) return 1.094621;
+    if (nvtx >= 31.000000 && nvtx < 32.000000) return 1.082620;
+    if (nvtx >= 32.000000 && nvtx < 33.000000) return 1.041247;
+    if (nvtx >= 33.000000 && nvtx < 34.000000) return 0.985752;
+    if (nvtx >= 34.000000 && nvtx < 35.000000) return 0.910807;
+    if (nvtx >= 35.000000 && nvtx < 36.000000) return 0.820923;
+    if (nvtx >= 36.000000 && nvtx < 37.000000) return 0.716787;
+    if (nvtx >= 37.000000 && nvtx < 38.000000) return 0.610013;
+    if (nvtx >= 38.000000 && nvtx < 39.000000) return 0.503118;
+    if (nvtx >= 39.000000 && nvtx < 40.000000) return 0.404841;
+    if (nvtx >= 40.000000 && nvtx < 41.000000) return 0.309195;
+    if (nvtx >= 41.000000 && nvtx < 42.000000) return 0.227920;
+    if (nvtx >= 42.000000 && nvtx < 43.000000) return 0.163690;
+    if (nvtx >= 43.000000 && nvtx < 44.000000) return 0.113180;
+    if (nvtx >= 44.000000 && nvtx < 45.000000) return 0.077300;
+    if (nvtx >= 45.000000 && nvtx < 46.000000) return 0.050922;
+    if (nvtx >= 46.000000 && nvtx < 47.000000) return 0.031894;
+    if (nvtx >= 47.000000 && nvtx < 48.000000) return 0.020094;
+    if (nvtx >= 48.000000 && nvtx < 49.000000) return 0.012263;
+    if (nvtx >= 49.000000 && nvtx < 50.000000) return 0.007426;
+    if (nvtx >= 50.000000 && nvtx < 51.000000) return 0.004380;
+    if (nvtx >= 51.000000 && nvtx < 52.000000) return 0.002608;
+    if (nvtx >= 52.000000 && nvtx < 53.000000) return 0.001566;
+    if (nvtx >= 53.000000 && nvtx < 54.000000) return 0.000971;
+    if (nvtx >= 54.000000 && nvtx < 55.000000) return 0.000729;
+    if (nvtx >= 55.000000 && nvtx < 56.000000) return 0.000673;
+    if (nvtx >= 56.000000 && nvtx < 57.000000) return 0.000730;
+    if (nvtx >= 57.000000 && nvtx < 58.000000) return 0.000949;
+    if (nvtx >= 58.000000 && nvtx < 59.000000) return 0.001355;
+    if (nvtx >= 59.000000 && nvtx < 60.000000) return 0.001894;
+    if (nvtx >= 60.000000 && nvtx < 61.000000) return 0.003082;
+    if (nvtx >= 61.000000 && nvtx < 62.000000) return 0.004097;
+    if (nvtx >= 62.000000 && nvtx < 63.000000) return 0.004874;
+    if (nvtx >= 63.000000 && nvtx < 64.000000) return 0.005256;
+    if (nvtx >= 64.000000 && nvtx < 65.000000) return 0.005785;
+    if (nvtx >= 65.000000 && nvtx < 66.000000) return 0.005515;
+    if (nvtx >= 66.000000 && nvtx < 67.000000) return 0.005000;
+    if (nvtx >= 67.000000 && nvtx < 68.000000) return 0.004410;
+    if (nvtx >= 68.000000 && nvtx < 69.000000) return 0.004012;
+    if (nvtx >= 69.000000 && nvtx < 70.000000) return 0.003548;
+    if (nvtx >= 70.000000 && nvtx < 71.000000) return 0.003108;
+    if (nvtx >= 71.000000 && nvtx < 72.000000) return 0.002702;
+    if (nvtx >= 72.000000 && nvtx < 73.000000) return 0.002337;
+    if (nvtx >= 73.000000 && nvtx < 74.000000) return 0.002025;
+    if (nvtx >= 74.000000 && nvtx < 75.000000) return 0.001723;
+    if (nvtx >= 75.000000 && nvtx < 76.000000) return 0.000000;
+    if (nvtx >= 76.000000 && nvtx < 77.000000) return 0.000000;
+    if (nvtx >= 77.000000 && nvtx < 78.000000) return 0.000000;
+    if (nvtx >= 78.000000 && nvtx < 79.000000) return 0.000000;
+    if (nvtx >= 79.000000 && nvtx < 80.000000) return 0.000000;
     return 0.;
 }
 
@@ -138,213 +138,290 @@ float getTruePUw_Moriond(int nvtx) {
     // if (nvtx>=48.000000 && nvtx<49.000000) return 0.015408;
     // if (nvtx>=49.000000 && nvtx<50.000000) return 0.009769;
     // below derived using CMS3
-    if (nvtx>=0.000000 && nvtx<1.000000) return 0.456317;
-    if (nvtx>=1.000000 && nvtx<2.000000) return 0.868822;
-    if (nvtx>=2.000000 && nvtx<3.000000) return 1.060915;
-    if (nvtx>=3.000000 && nvtx<4.000000) return 0.804616;
-    if (nvtx>=4.000000 && nvtx<5.000000) return 1.279666;
-    if (nvtx>=5.000000 && nvtx<6.000000) return 1.377812;
-    if (nvtx>=6.000000 && nvtx<7.000000) return 0.704106;
-    if (nvtx>=7.000000 && nvtx<8.000000) return 0.494254;
-    if (nvtx>=8.000000 && nvtx<9.000000) return 0.718032;
-    if (nvtx>=9.000000 && nvtx<10.000000) return 0.853469;
-    if (nvtx>=10.000000 && nvtx<11.000000) return 0.938278;
-    if (nvtx>=11.000000 && nvtx<12.000000) return 1.057068;
-    if (nvtx>=12.000000 && nvtx<13.000000) return 1.122293;
-    if (nvtx>=13.000000 && nvtx<14.000000) return 1.153207;
-    if (nvtx>=14.000000 && nvtx<15.000000) return 1.205728;
-    if (nvtx>=15.000000 && nvtx<16.000000) return 1.198719;
-    if (nvtx>=16.000000 && nvtx<17.000000) return 1.184970;
-    if (nvtx>=17.000000 && nvtx<18.000000) return 1.176247;
-    if (nvtx>=18.000000 && nvtx<19.000000) return 1.127847;
-    if (nvtx>=19.000000 && nvtx<20.000000) return 1.083409;
-    if (nvtx>=20.000000 && nvtx<21.000000) return 1.063132;
-    if (nvtx>=21.000000 && nvtx<22.000000) return 1.042620;
-    if (nvtx>=22.000000 && nvtx<23.000000) return 1.045930;
-    if (nvtx>=23.000000 && nvtx<24.000000) return 1.047821;
-    if (nvtx>=24.000000 && nvtx<25.000000) return 1.042626;
-    if (nvtx>=25.000000 && nvtx<26.000000) return 1.056079;
-    if (nvtx>=26.000000 && nvtx<27.000000) return 1.068642;
-    if (nvtx>=27.000000 && nvtx<28.000000) return 1.077145;
-    if (nvtx>=28.000000 && nvtx<29.000000) return 1.090889;
-    if (nvtx>=29.000000 && nvtx<30.000000) return 1.102057;
-    if (nvtx>=30.000000 && nvtx<31.000000) return 1.089665;
-    if (nvtx>=31.000000 && nvtx<32.000000) return 1.066530;
-    if (nvtx>=32.000000 && nvtx<33.000000) return 1.037292;
-    if (nvtx>=33.000000 && nvtx<34.000000) return 0.969761;
-    if (nvtx>=34.000000 && nvtx<35.000000) return 0.900420;
-    if (nvtx>=35.000000 && nvtx<36.000000) return 0.814996;
-    if (nvtx>=36.000000 && nvtx<37.000000) return 0.701494;
-    if (nvtx>=37.000000 && nvtx<38.000000) return 0.601403;
-    if (nvtx>=38.000000 && nvtx<39.000000) return 0.492305;
-    if (nvtx>=39.000000 && nvtx<40.000000) return 0.400363;
-    if (nvtx>=40.000000 && nvtx<41.000000) return 0.308498;
-    if (nvtx>=41.000000 && nvtx<42.000000) return 0.225170;
-    if (nvtx>=42.000000 && nvtx<43.000000) return 0.162180;
-    if (nvtx>=43.000000 && nvtx<44.000000) return 0.111863;
-    if (nvtx>=44.000000 && nvtx<45.000000) return 0.077390;
-    if (nvtx>=45.000000 && nvtx<46.000000) return 0.050697;
-    if (nvtx>=46.000000 && nvtx<47.000000) return 0.031394;
-    if (nvtx>=47.000000 && nvtx<48.000000) return 0.020052;
-    if (nvtx>=48.000000 && nvtx<49.000000) return 0.012629;
-    if (nvtx>=49.000000 && nvtx<50.000000) return 0.007430;
+    if (nvtx >= 0.000000 && nvtx < 1.000000) return 0.456317;
+    if (nvtx >= 1.000000 && nvtx < 2.000000) return 0.868822;
+    if (nvtx >= 2.000000 && nvtx < 3.000000) return 1.060915;
+    if (nvtx >= 3.000000 && nvtx < 4.000000) return 0.804616;
+    if (nvtx >= 4.000000 && nvtx < 5.000000) return 1.279666;
+    if (nvtx >= 5.000000 && nvtx < 6.000000) return 1.377812;
+    if (nvtx >= 6.000000 && nvtx < 7.000000) return 0.704106;
+    if (nvtx >= 7.000000 && nvtx < 8.000000) return 0.494254;
+    if (nvtx >= 8.000000 && nvtx < 9.000000) return 0.718032;
+    if (nvtx >= 9.000000 && nvtx < 10.000000) return 0.853469;
+    if (nvtx >= 10.000000 && nvtx < 11.000000) return 0.938278;
+    if (nvtx >= 11.000000 && nvtx < 12.000000) return 1.057068;
+    if (nvtx >= 12.000000 && nvtx < 13.000000) return 1.122293;
+    if (nvtx >= 13.000000 && nvtx < 14.000000) return 1.153207;
+    if (nvtx >= 14.000000 && nvtx < 15.000000) return 1.205728;
+    if (nvtx >= 15.000000 && nvtx < 16.000000) return 1.198719;
+    if (nvtx >= 16.000000 && nvtx < 17.000000) return 1.184970;
+    if (nvtx >= 17.000000 && nvtx < 18.000000) return 1.176247;
+    if (nvtx >= 18.000000 && nvtx < 19.000000) return 1.127847;
+    if (nvtx >= 19.000000 && nvtx < 20.000000) return 1.083409;
+    if (nvtx >= 20.000000 && nvtx < 21.000000) return 1.063132;
+    if (nvtx >= 21.000000 && nvtx < 22.000000) return 1.042620;
+    if (nvtx >= 22.000000 && nvtx < 23.000000) return 1.045930;
+    if (nvtx >= 23.000000 && nvtx < 24.000000) return 1.047821;
+    if (nvtx >= 24.000000 && nvtx < 25.000000) return 1.042626;
+    if (nvtx >= 25.000000 && nvtx < 26.000000) return 1.056079;
+    if (nvtx >= 26.000000 && nvtx < 27.000000) return 1.068642;
+    if (nvtx >= 27.000000 && nvtx < 28.000000) return 1.077145;
+    if (nvtx >= 28.000000 && nvtx < 29.000000) return 1.090889;
+    if (nvtx >= 29.000000 && nvtx < 30.000000) return 1.102057;
+    if (nvtx >= 30.000000 && nvtx < 31.000000) return 1.089665;
+    if (nvtx >= 31.000000 && nvtx < 32.000000) return 1.066530;
+    if (nvtx >= 32.000000 && nvtx < 33.000000) return 1.037292;
+    if (nvtx >= 33.000000 && nvtx < 34.000000) return 0.969761;
+    if (nvtx >= 34.000000 && nvtx < 35.000000) return 0.900420;
+    if (nvtx >= 35.000000 && nvtx < 36.000000) return 0.814996;
+    if (nvtx >= 36.000000 && nvtx < 37.000000) return 0.701494;
+    if (nvtx >= 37.000000 && nvtx < 38.000000) return 0.601403;
+    if (nvtx >= 38.000000 && nvtx < 39.000000) return 0.492305;
+    if (nvtx >= 39.000000 && nvtx < 40.000000) return 0.400363;
+    if (nvtx >= 40.000000 && nvtx < 41.000000) return 0.308498;
+    if (nvtx >= 41.000000 && nvtx < 42.000000) return 0.225170;
+    if (nvtx >= 42.000000 && nvtx < 43.000000) return 0.162180;
+    if (nvtx >= 43.000000 && nvtx < 44.000000) return 0.111863;
+    if (nvtx >= 44.000000 && nvtx < 45.000000) return 0.077390;
+    if (nvtx >= 45.000000 && nvtx < 46.000000) return 0.050697;
+    if (nvtx >= 46.000000 && nvtx < 47.000000) return 0.031394;
+    if (nvtx >= 47.000000 && nvtx < 48.000000) return 0.020052;
+    if (nvtx >= 48.000000 && nvtx < 49.000000) return 0.012629;
+    if (nvtx >= 49.000000 && nvtx < 50.000000) return 0.007430;
     return 0.;
 }
 
-
-float triggerScaleFactor(int pdgId1, int pdgId2, float pt1, float pt2, float eta1, float eta2, float ht) {
+float triggerScaleFactor(int pdgId1, int pdgId2, float pt1, float pt2,
+                         float eta1, float eta2, float ht) {
     // return TotalTriggerSF(pdgId1, pt1, eta1, pdgId2, pt2, eta2, ht);
     // Using Matthieu's macro, so dummy 1 here
-    return 1.0; // FIXME
+    return 1.0;  // FIXME
 
-
-    if (ht>300) {
-	if ((abs(pdgId1)+abs(pdgId2))==22) return 1.;
-	if ((abs(pdgId1)+abs(pdgId2))==26) return 0.985*0.985;
-	if ((abs(pdgId1)+abs(pdgId2))==24) return 0.985;
+    if (ht > 300) {
+        if ((abs(pdgId1) + abs(pdgId2)) == 22) return 1.;
+        if ((abs(pdgId1) + abs(pdgId2)) == 26) return 0.985 * 0.985;
+        if ((abs(pdgId1) + abs(pdgId2)) == 24) return 0.985;
     } else {
-	if ((abs(pdgId1)+abs(pdgId2))==22) return 0.997*0.997*0.998;
-	if ((abs(pdgId1)+abs(pdgId2))==26) return 0.982*0.985*0.973;
-	if ((abs(pdgId1)+abs(pdgId2))==24) {
-	    if (abs(pdgId1)==11) {
-		if (pt1>pt2) return 0.997*0.985;
-		else return 0.997*0.982;
-	    } else {
-		if (pt1>pt2) return 0.997*0.982;
-		else return 0.997*0.985;
-	    }
-	}
+        if ((abs(pdgId1) + abs(pdgId2)) == 22) return 0.997 * 0.997 * 0.998;
+        if ((abs(pdgId1) + abs(pdgId2)) == 26) return 0.982 * 0.985 * 0.973;
+        if ((abs(pdgId1) + abs(pdgId2)) == 24) {
+            if (abs(pdgId1) == 11) {
+                if (pt1 > pt2)
+                    return 0.997 * 0.985;
+                else
+                    return 0.997 * 0.982;
+            } else {
+                if (pt1 > pt2)
+                    return 0.997 * 0.982;
+                else
+                    return 0.997 * 0.985;
+            }
+        }
     }
     return 0.;
 }
 
 float electronScaleFactorHighHT(float pt, float eta) {
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9158;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9820;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 1.0756;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9203;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 1.1124;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9177;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9499;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9710;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9370;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9904;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9210;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9472;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9927;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9443;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9785;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9213;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9515;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9830;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9480;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9628;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9212;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9483;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9845;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9480;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9483;
-    if (pt >= 100  && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9469;
-    if (pt >= 100  && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9429;
-    if (pt >= 100  && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9932;
-    if (pt >= 100  && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9455;
-    if (pt >= 100  && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9592;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9158;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9820;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 1.0756;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9203;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 1.1124;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9177;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9499;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9710;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9370;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9904;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9210;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9472;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9927;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9443;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9785;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9213;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9515;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9830;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9480;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9628;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9212;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9483;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9845;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9480;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9483;
+    if (pt >= 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9469;
+    if (pt >= 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9429;
+    if (pt >= 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9932;
+    if (pt >= 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9455;
+    if (pt >= 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9592;
     return 0.;
 }
 float electronScaleFactorLowHT(float pt, float eta) {
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9149;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9768;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 1.0781;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9169;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 1.1100;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9170;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9497;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9687;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9356;
-    if (pt >= 20 && pt < 30 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9894;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9208;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9483;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9923;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9438;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9781;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9202;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9514;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9827;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9480;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9627;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9207;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9481;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9848;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9480;
-    if (pt >= 50 && pt < 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9477;
-    if (pt >= 100  && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9472;
-    if (pt >= 100  && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9333;
-    if (pt >= 100  && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9934;
-    if (pt >= 100  && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9383;
-    if (pt >= 100  && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9597;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9149;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9768;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 1.0781;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9169;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 1.1100;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9170;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9497;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9687;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9356;
+    if (pt >= 20 && pt < 30 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9894;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9208;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9483;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9923;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9438;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9781;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9202;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9514;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9827;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9480;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9627;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800)
+        return 0.9207;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442)
+        return 0.9481;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566)
+        return 0.9848;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000)
+        return 0.9480;
+    if (pt >= 50 && pt < 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500)
+        return 0.9477;
+    if (pt >= 100 && fabs(eta) >= 0.000 && fabs(eta) < 0.800) return 0.9472;
+    if (pt >= 100 && fabs(eta) >= 0.800 && fabs(eta) < 1.442) return 0.9333;
+    if (pt >= 100 && fabs(eta) >= 1.442 && fabs(eta) < 1.566) return 0.9934;
+    if (pt >= 100 && fabs(eta) >= 1.566 && fabs(eta) < 2.000) return 0.9383;
+    if (pt >= 100 && fabs(eta) >= 2.000 && fabs(eta) < 2.500) return 0.9597;
     return 0.;
 }
 float muonScaleFactor(float pt, float eta) {
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9047;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.8860;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.8916;
-    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.8394;
-    if (pt >= 20 && pt < 25 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9430;
-    if (pt >= 20 && pt < 25 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9685;
-    if (pt >= 20 && pt < 25 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9741;
-    if (pt >= 20 && pt < 25 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.8917;
-    if (pt >= 25 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9707;
-    if (pt >= 25 && pt < 30 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9724;
-    if (pt >= 25 && pt < 30 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9777;
-    if (pt >= 25 && pt < 30 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9180;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9821;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9850;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9934;
-    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9389;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9854;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9861;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9968;
-    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9453;
-    if (pt >= 50 && pt < 60 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9813;
-    if (pt >= 50 && pt < 60 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9819;
-    if (pt >= 50 && pt < 60 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9964;
-    if (pt >= 50 && pt < 60 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9410;
-    if (pt >= 60  && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9830;
-    if (pt >= 60  && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9861;
-    if (pt >= 60  && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9994;
-    if (pt >= 60  && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9525;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9047;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.8860;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.8916;
+    if (pt >= 10 && pt < 20 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.8394;
+    if (pt >= 20 && pt < 25 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9430;
+    if (pt >= 20 && pt < 25 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.9685;
+    if (pt >= 20 && pt < 25 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.9741;
+    if (pt >= 20 && pt < 25 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.8917;
+    if (pt >= 25 && pt < 30 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9707;
+    if (pt >= 25 && pt < 30 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.9724;
+    if (pt >= 25 && pt < 30 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.9777;
+    if (pt >= 25 && pt < 30 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.9180;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9821;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.9850;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.9934;
+    if (pt >= 30 && pt < 40 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.9389;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9854;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.9861;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.9968;
+    if (pt >= 40 && pt < 50 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.9453;
+    if (pt >= 50 && pt < 60 && fabs(eta) >= 0.000 && fabs(eta) < 0.900)
+        return 0.9813;
+    if (pt >= 50 && pt < 60 && fabs(eta) >= 0.900 && fabs(eta) < 1.200)
+        return 0.9819;
+    if (pt >= 50 && pt < 60 && fabs(eta) >= 1.200 && fabs(eta) < 2.100)
+        return 0.9964;
+    if (pt >= 50 && pt < 60 && fabs(eta) >= 2.100 && fabs(eta) < 2.400)
+        return 0.9410;
+    if (pt >= 60 && fabs(eta) >= 0.000 && fabs(eta) < 0.900) return 0.9830;
+    if (pt >= 60 && fabs(eta) >= 0.900 && fabs(eta) < 1.200) return 0.9861;
+    if (pt >= 60 && fabs(eta) >= 1.200 && fabs(eta) < 2.100) return 0.9994;
+    if (pt >= 60 && fabs(eta) >= 2.100 && fabs(eta) < 2.400) return 0.9525;
     return 0.;
 }
 
 float electronGSF(float pt, float eta) {
-    if (pt >= 20  && eta >= -2.500 && eta < -2.400) return 1.1703;
-    if (pt >= 20  && eta >= -2.400 && eta < -2.300) return 1.0085;
-    if (pt >= 20  && eta >= -2.300 && eta < -2.200) return 1.0105;
-    if (pt >= 20  && eta >= -2.200 && eta < -2.000) return 1.0052;
-    if (pt >= 20  && eta >= -2.000 && eta < -1.800) return 0.9979;
-    if (pt >= 20  && eta >= -1.800 && eta < -1.630) return 0.9917;
-    if (pt >= 20  && eta >= -1.630 && eta < -1.566) return 0.9865;
-    if (pt >= 20  && eta >= -1.566 && eta < -1.444) return 0.9616;
-    if (pt >= 20  && eta >= -1.444 && eta < -1.200) return 0.9867;
-    if (pt >= 20  && eta >= -1.200 && eta < -1.000) return 0.9775;
-    if (pt >= 20  && eta >= -1.000 && eta < -0.600) return 0.9694;
-    if (pt >= 20  && eta >= -0.600 && eta < -0.400) return 0.9664;
-    if (pt >= 20  && eta >= -0.400 && eta < -0.200) return 0.9633;
-    if (pt >= 20  && eta >= -0.200 && eta < 0.000) return 0.9600;
-    if (pt >= 20  && eta >= 0.000 && eta < 0.200) return 0.9662;
-    if (pt >= 20  && eta >= 0.200 && eta < 0.400) return 0.9796;
-    if (pt >= 20  && eta >= 0.400 && eta < 0.600) return 0.9766;
-    if (pt >= 20  && eta >= 0.600 && eta < 1.000) return 0.9807;
-    if (pt >= 20  && eta >= 1.000 && eta < 1.200) return 0.9867;
-    if (pt >= 20  && eta >= 1.200 && eta < 1.444) return 0.9867;
-    if (pt >= 20  && eta >= 1.444 && eta < 1.566) return 0.9707;
-    if (pt >= 20  && eta >= 1.566 && eta < 1.630) return 0.9897;
-    if (pt >= 20  && eta >= 1.630 && eta < 1.800) return 0.9959;
-    if (pt >= 20  && eta >= 1.800 && eta < 2.000) return 0.9897;
-    if (pt >= 20  && eta >= 2.000 && eta < 2.200) return 0.9949;
-    if (pt >= 20  && eta >= 2.200 && eta < 2.300) return 0.9928;
-    if (pt >= 20  && eta >= 2.300 && eta < 2.400) return 0.9666;
-    if (pt >= 20  && eta >= 2.400 && eta < 2.500) return 0.8840;
+    if (pt >= 20 && eta >= -2.500 && eta < -2.400) return 1.1703;
+    if (pt >= 20 && eta >= -2.400 && eta < -2.300) return 1.0085;
+    if (pt >= 20 && eta >= -2.300 && eta < -2.200) return 1.0105;
+    if (pt >= 20 && eta >= -2.200 && eta < -2.000) return 1.0052;
+    if (pt >= 20 && eta >= -2.000 && eta < -1.800) return 0.9979;
+    if (pt >= 20 && eta >= -1.800 && eta < -1.630) return 0.9917;
+    if (pt >= 20 && eta >= -1.630 && eta < -1.566) return 0.9865;
+    if (pt >= 20 && eta >= -1.566 && eta < -1.444) return 0.9616;
+    if (pt >= 20 && eta >= -1.444 && eta < -1.200) return 0.9867;
+    if (pt >= 20 && eta >= -1.200 && eta < -1.000) return 0.9775;
+    if (pt >= 20 && eta >= -1.000 && eta < -0.600) return 0.9694;
+    if (pt >= 20 && eta >= -0.600 && eta < -0.400) return 0.9664;
+    if (pt >= 20 && eta >= -0.400 && eta < -0.200) return 0.9633;
+    if (pt >= 20 && eta >= -0.200 && eta < 0.000) return 0.9600;
+    if (pt >= 20 && eta >= 0.000 && eta < 0.200) return 0.9662;
+    if (pt >= 20 && eta >= 0.200 && eta < 0.400) return 0.9796;
+    if (pt >= 20 && eta >= 0.400 && eta < 0.600) return 0.9766;
+    if (pt >= 20 && eta >= 0.600 && eta < 1.000) return 0.9807;
+    if (pt >= 20 && eta >= 1.000 && eta < 1.200) return 0.9867;
+    if (pt >= 20 && eta >= 1.200 && eta < 1.444) return 0.9867;
+    if (pt >= 20 && eta >= 1.444 && eta < 1.566) return 0.9707;
+    if (pt >= 20 && eta >= 1.566 && eta < 1.630) return 0.9897;
+    if (pt >= 20 && eta >= 1.630 && eta < 1.800) return 0.9959;
+    if (pt >= 20 && eta >= 1.800 && eta < 2.000) return 0.9897;
+    if (pt >= 20 && eta >= 2.000 && eta < 2.200) return 0.9949;
+    if (pt >= 20 && eta >= 2.200 && eta < 2.300) return 0.9928;
+    if (pt >= 20 && eta >= 2.300 && eta < 2.400) return 0.9666;
+    if (pt >= 20 && eta >= 2.400 && eta < 2.500) return 0.8840;
     return 0.;
 }
 
@@ -353,27 +430,32 @@ float trackingSF(float eta) {
     if (eta >= -2.100 && eta < -1.600) return 0.9939;
     if (eta >= -1.600 && eta < -1.100) return 0.9970;
     if (eta >= -1.100 && eta < -0.600) return 0.9954;
-    if (eta >= -0.600 && eta <  0.000) return 0.9937;
-    if (eta >=  0.000 && eta <  0.600) return 0.9959;
-    if (eta >=  0.600 && eta <  1.100) return 0.9976;
-    if (eta >=  1.100 && eta <  1.600) return 0.9961;
-    if (eta >=  1.600 && eta <  2.100) return 0.9930;
-    if (eta >=  2.100 && eta <  2.400) return 0.9819;
+    if (eta >= -0.600 && eta < 0.000) return 0.9937;
+    if (eta >= 0.000 && eta < 0.600) return 0.9959;
+    if (eta >= 0.600 && eta < 1.100) return 0.9976;
+    if (eta >= 1.100 && eta < 1.600) return 0.9961;
+    if (eta >= 1.600 && eta < 2.100) return 0.9930;
+    if (eta >= 2.100 && eta < 2.400) return 0.9819;
     return 1.0;
 }
 
 float leptonScaleFactor(int pdgId, float pt, float eta, float ht) {
-    if (abs(pdgId)==13) return muonScaleFactor(pt, eta)*trackingSF(eta);
-    else if (abs(pdgId)==11){
-	if (ht>300) return electronScaleFactorHighHT(pt, eta)*electronGSF(pt, eta);
-	else return electronScaleFactorLowHT(pt, eta)*electronGSF(pt, eta);
+    if (abs(pdgId) == 13)
+        return muonScaleFactor(pt, eta) * trackingSF(eta);
+    else if (abs(pdgId) == 11) {
+        if (ht > 300)
+            return electronScaleFactorHighHT(pt, eta) * electronGSF(pt, eta);
+        else
+            return electronScaleFactorLowHT(pt, eta) * electronGSF(pt, eta);
     }
     return 0.;
 }
 
-float eventScaleFactor(int pdgId1, int pdgId2, float pt1, float pt2, float eta1, float eta2, float ht) {
-    return triggerScaleFactor(pdgId1, pdgId2, pt1, pt2, eta1, eta2, ht) * leptonScaleFactor(pdgId1, pt1, eta1, ht) * leptonScaleFactor(pdgId2, pt2, eta2, ht);
+float eventScaleFactor(int pdgId1, int pdgId2, float pt1, float pt2, float eta1,
+                       float eta2, float ht) {
+    return triggerScaleFactor(pdgId1, pdgId2, pt1, pt2, eta1, eta2, ht) *
+           leptonScaleFactor(pdgId1, pt1, eta1, ht) *
+           leptonScaleFactor(pdgId2, pt2, eta2, ht);
 }
-
 
 #endif

--- a/interface/GoodParticle.h
+++ b/interface/GoodParticle.h
@@ -7,94 +7,97 @@
 // accessing data if particle is muon vs electron
 
 struct GoodPart {
-    enum JET_STATUS {NONE=0, PASS_JET=1, PASS_BJET=2, PASS_BOTH=3};
+    enum JET_STATUS { NONE = 0, PASS_JET = 1, PASS_BJET = 2, PASS_BOTH = 3 };
     LorentzVector v;
     int pdgId;
-    int jetStatus=NONE;
+    int jetStatus = NONE;
     int index;
-    GoodPart(){}
-  
-    GoodPart(double pt, double eta, double phi, double m, int pdg=0 ) : v(pt, eta, phi, m), pdgId(pdg) {}
-    GoodPart(LorentzVector v_, int pdg=0 ) : v(v_), pdgId(pdg) {}
+    GoodPart() {}
+
+    GoodPart(double pt, double eta, double phi, double m, int pdg = 0)
+        : v(pt, eta, phi, m), pdgId(pdg) {}
+    GoodPart(LorentzVector v_, int pdg = 0) : v(v_), pdgId(pdg) {}
     double operator[](int index) {
-        if(index == 1) return v.Px();
-	else if(index == 2) return v.Py();
-	else if(index == 3) return v.Pz();
-	else return -1;	
+        if (index == 1)
+            return v.Px();
+        else if (index == 2)
+            return v.Py();
+        else if (index == 3)
+            return v.Pz();
+        else
+            return -1;
     }
 
-    void SetPdgId(int pdg) {
-	pdgId = pdg;
-    }
-      
-    double Pt() {return v.Pt();}
-    double Eta() {return v.Eta();}
-    double Phi() {return v.Phi();}
-    double M() {return v.M();}
-    double E() {return v.E();}
-    
-    int Charge() {return pdgId;}
-    int Id() {return std::abs(pdgId);}
+    void SetPdgId(int pdg) { pdgId = pdg; }
 
-    void setPassJetSel() {jetStatus += PASS_JET;}
-    void setPassBJetSel() {jetStatus += PASS_BJET;}
+    double Pt() { return v.Pt(); }
+    double Eta() { return v.Eta(); }
+    double Phi() { return v.Phi(); }
+    double M() { return v.M(); }
+    double E() { return v.E(); }
 
-    bool passedJetSel() {return jetStatus % 2 == 1;}
-    bool passedBJetSel() {return jetStatus / 2 == 1;}
+    int Charge() { return pdgId; }
+    int Id() { return std::abs(pdgId); }
+
+    void setPassJetSel() { jetStatus += PASS_JET; }
+    void setPassBJetSel() { jetStatus += PASS_BJET; }
+
+    bool passedJetSel() { return jetStatus % 2 == 1; }
+    bool passedBJetSel() { return jetStatus / 2 == 1; }
 };
 
-
-
-//Seems a little less clunky
-//Can also add some help functions as time goes on
+// Seems a little less clunky
+// Can also add some help functions as time goes on
 struct GenPart {
-    enum Match {NONE=0, GEN_ONLY=1, RECO_ONLY=2, MATCHED=3};
-    enum BMatch {bNONE=0, bGEN_ONLY=1, bRECO_ONLY=2, bMATCHED=3};
-    
+    enum Match { NONE = 0, GEN_ONLY = 1, RECO_ONLY = 2, MATCHED = 3 };
+    enum BMatch { bNONE = 0, bGEN_ONLY = 1, bRECO_ONLY = 2, bMATCHED = 3 };
+
     GoodPart gen;
     GoodPart reco;
     int status = NONE;
     int bstatus = bNONE;
-   
+
     void SetupGen(double pt, double eta, double phi, double m, int pdg) {
-	gen = GoodPart(pt, eta, phi, m, pdg);
-	status += GEN_ONLY;
-	if(pdg == 5) bstatus += bGEN_ONLY;
+        gen = GoodPart(pt, eta, phi, m, pdg);
+        status += GEN_ONLY;
+        if (pdg == 5) bstatus += bGEN_ONLY;
     }
 
     void SetupReco(GoodPart& reco_) {
-	reco = reco_;
-	status += RECO_ONLY;
-	if(reco.passedBJetSel()) bstatus += bRECO_ONLY;
+        reco = reco_;
+        status += RECO_ONLY;
+        if (reco.passedBJetSel()) bstatus += bRECO_ONLY;
     }
 
     int Id() {
-	if(status % 2 == 1) return gId();
-	else return rId();
+        if (status % 2 == 1)
+            return gId();
+        else
+            return rId();
     }
-    
-    int gId() {return gen.Id();}
-    double gPt() {return gen.Pt();}
-    double gEta() {return gen.Eta();}
-    double gPhi() {return gen.Phi();}
-    double gM() {return gen.M();}
-    LorentzVector gVector(){return gen.v;}
 
-    int rId() {return reco.Id();}
-    double rPt() {return reco.Pt();}
-    double rEta() {return reco.Eta();}
-    double rPhi() {return reco.Phi();}
-    double rM() {return reco.M();}
-    LorentzVector rVector(){return reco.v;}
+    int gId() { return gen.Id(); }
+    double gPt() { return gen.Pt(); }
+    double gEta() { return gen.Eta(); }
+    double gPhi() { return gen.Phi(); }
+    double gM() { return gen.M(); }
+    LorentzVector gVector() { return gen.v; }
 
-    bool isMatched() {return status == MATCHED;}
-    bool isFaked() {return status == RECO_ONLY;}
-    bool noMatched() {return status == GEN_ONLY;}
-    
-    bool isBMatched() {return bstatus == bMATCHED;}
-    bool isBFaked() {return bstatus == bRECO_ONLY;}
-    bool noBMatched() {return bstatus == bGEN_ONLY;}
-    bool isGenB() {return bstatus % 2 == 1;}
+    int rId() { return reco.Id(); }
+    double rPt() { return reco.Pt(); }
+    double rEta() { return reco.Eta(); }
+    double rPhi() { return reco.Phi(); }
+    double rM() { return reco.M(); }
+    LorentzVector rVector() { return reco.v; }
+
+    bool isMatched() { return status == MATCHED; }
+    bool isFaked() { return status == RECO_ONLY; }
+    bool noMatched() { return status == GEN_ONLY; }
+
+    bool isBMatched() { return bstatus == bMATCHED; }
+    bool isBFaked() { return bstatus == bRECO_ONLY; }
+    bool noBMatched() { return bstatus == bGEN_ONLY; }
+    bool isGenB() { return bstatus % 2 == 1; }
 };
 
 #endif

--- a/interface/HelperFunctions.h
+++ b/interface/HelperFunctions.h
@@ -10,29 +10,28 @@
 double JetSphericity(std::vector<GoodPart>& jets) {
     TMatrixDSym sphere(3);
     double pSum = 0;
-    for(auto jet: jets) {
-	for(int i = 1; i <= 3; i++) {
-	    sphere(i-1,i-1) += pow(jet[i], 2);
-	    pSum += pow(jet[i], 2);
-	    for(int j = i+1; j <= 3; j++) {
-		sphere(i-1,j-1) += jet[i]*jet[j];
-		sphere(j-1,i-1) += jet[i]*jet[j];
-	    }
-	}
+    for (auto jet : jets) {
+        for (int i = 1; i <= 3; i++) {
+            sphere(i - 1, i - 1) += pow(jet[i], 2);
+            pSum += pow(jet[i], 2);
+            for (int j = i + 1; j <= 3; j++) {
+                sphere(i - 1, j - 1) += jet[i] * jet[j];
+                sphere(j - 1, i - 1) += jet[i] * jet[j];
+            }
+        }
     }
-    sphere *= 1/pSum;
+    sphere *= 1 / pSum;
     TMatrixDSymEigen eigenGetter(sphere);
     TVectorD eigen = eigenGetter.GetEigenValues();
-    return 3./2*(eigen(1) + eigen(2));
+    return 3. / 2 * (eigen(1) + eigen(2));
 }
 
 double JetCentrality(std::vector<GoodPart>& jets, double HT) {
     double eTot = 0;
-    for(auto jet: jets) {
-	eTot += jet.E();
+    for (auto jet : jets) {
+        eTot += jet.E();
     }
-    return HT/eTot;
+    return HT / eTot;
 }
 
 #endif /* HELPERFUNCTIONS_H */
-

--- a/interface/LowPileupSelector.h
+++ b/interface/LowPileupSelector.h
@@ -1,26 +1,26 @@
 #ifndef LowPileupSelector_h
 #define LowPileupSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TLorentzVector.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
+#include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include "Analysis/VVAnalysis/interface/BranchManager.h"
 
 #include "Analysis/VVAnalysis/interface/helpers.h"
 
 class LowPileupSelector : public SelectorBase {
-public :
+   public:
     // Derived values
     float weight;
     TLorentzVector pfMetVec;
@@ -39,16 +39,17 @@ public :
     BranchManager b;
 
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    LowPileupSelector(TTree * /*tree*/ =0) { }
-    ~LowPileupSelector() { }
-    virtual void    SetupNewDirectory() override;
+    virtual void Init(TTree *tree) override;
+    LowPileupSelector(TTree * /*tree*/ = 0) {}
+    ~LowPileupSelector() {}
+    virtual void SetupNewDirectory() override;
 
-    ClassDefOverride(LowPileupSelector,0);
+    ClassDefOverride(LowPileupSelector, 0);
 
-protected:
-    virtual void    SetBranchesBacon() override;
-    void LoadBranchesBacon(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+   protected:
+    virtual void SetBranchesBacon() override;
+    void LoadBranchesBacon(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     virtual void SetComposite() {}
 };
 

--- a/interface/LowPileupWBackgroundSelector.h
+++ b/interface/LowPileupWBackgroundSelector.h
@@ -4,21 +4,17 @@
 #include "Analysis/VVAnalysis/interface/LowPileupWSelector.h"
 
 class LowPileupWBackgroundSelector : public LowPileupWSelector {
-public :
-    LowPileupWBackgroundSelector(TTree * /*tree*/ =0) { }
-    ~LowPileupWBackgroundSelector() { }
-    virtual void    Init(TTree *tree) override;
+   public:
+    LowPileupWBackgroundSelector(TTree * /*tree*/ = 0) {}
+    ~LowPileupWBackgroundSelector() {}
+    virtual void Init(TTree *tree) override;
 
-    ClassDefOverride(LowPileupWBackgroundSelector,0);
+    ClassDefOverride(LowPileupWBackgroundSelector, 0);
 
-protected:
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    virtual void    SetupNewDirectory() override;
+   protected:
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
+    virtual void SetupNewDirectory() override;
 };
 
 #endif
-
-
-
-
-

--- a/interface/LowPileupWSelector.h
+++ b/interface/LowPileupWSelector.h
@@ -1,36 +1,36 @@
 #ifndef LowPileupWSelector_h
 #define LowPileupWSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TLorentzVector.h>
+#include <TROOT.h>
+#include <TSelector.h>
+#include <TTreeReader.h>
+#include <TTreeReaderArray.h>
+#include <TTreeReaderValue.h>
 #include <exception>
 #include <iostream>
-#include <TTreeReader.h>
-#include <TTreeReaderValue.h>
-#include <TTreeReaderArray.h>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/LowPileupSelector.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 
 #include "Analysis/VVAnalysis/interface/helpers.h"
 
 class LowPileupWSelector : public LowPileupSelector {
-public :
+   public:
     // Derived values
     TLorentzVector wCand;
     TLorentzVector* met;
 
     // Mixing quite a lot of things here, but it makes it easier
-    TTreeReader     fReader;
+    TTreeReader fReader;
     TTreeReaderArray<double> evtWeight = {fReader, "evtWeight"};
     TTreeReaderArray<double> metVector = {fReader, "metVars"};
     TTreeReaderArray<double> metPhiVector = {fReader, "metVarsPhi"};
@@ -44,23 +44,21 @@ public :
 
     std::unordered_map<Systematic, size_t> systematicWeightMap_;
     std::unordered_map<Systematic, size_t> metCorrWeightMap_;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    LowPileupWSelector(TTree * /*tree*/ =0) { }
-    ~LowPileupWSelector() { }
+    virtual void Init(TTree* tree) override;
+    LowPileupWSelector(TTree* /*tree*/ = 0) {}
+    ~LowPileupWSelector() {}
 
-    ClassDefOverride(LowPileupWSelector,0);
+    ClassDefOverride(LowPileupWSelector, 0);
 
-protected:
-    virtual void    SetBranchesBacon() override;
-    void LoadBranchesBacon(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+   protected:
+    virtual void SetBranchesBacon() override;
+    void LoadBranchesBacon(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     virtual void SetComposite() override;
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
 };
 
 #endif
-
-
-
-

--- a/interface/LowPileupZSelector.h
+++ b/interface/LowPileupZSelector.h
@@ -1,28 +1,28 @@
 #ifndef LowPileupZSelector_h
 #define LowPileupZSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TLorentzVector.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/LowPileupSelector.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 
-#include "Analysis/VVAnalysis/interface/helpers.h"
 #include <TSelector.h>
+#include "Analysis/VVAnalysis/interface/helpers.h"
 
 class LowPileupZSelector : public LowPileupSelector {
-public :
+   public:
     // Derived values
     TLorentzVector zCand;
 
@@ -36,23 +36,22 @@ public :
     TBranch* lep1_b;
     TBranch* lep2_b;
 
-    enum { eMuMu2HLT=1, eMuMu1HLT, eMuMuNoSel, eMuSta, eMuTrk };
-    
+    enum { eMuMu2HLT = 1, eMuMu1HLT, eMuMuNoSel, eMuSta, eMuTrk };
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    LowPileupZSelector(TTree * /*tree*/ =0) { }
-    ~LowPileupZSelector() { }
+    virtual void Init(TTree* tree) override;
+    LowPileupZSelector(TTree* /*tree*/ = 0) {}
+    ~LowPileupZSelector() {}
 
-    ClassDefOverride(LowPileupZSelector,0);
+    ClassDefOverride(LowPileupZSelector, 0);
 
-protected:
-    virtual void    SetBranchesBacon() override;
-    void LoadBranchesBacon(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+   protected:
+    virtual void SetBranchesBacon() override;
+    void LoadBranchesBacon(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     virtual void SetComposite() override;
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
 };
 
 #endif
-
-
-

--- a/interface/NanoGenSelectorBase.h
+++ b/interface/NanoGenSelectorBase.h
@@ -1,29 +1,29 @@
 #ifndef NanoGenSelectorBase_h
 #define NanoGenSelectorBase_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TROOT.h>
+#include <TSelector.h>
+#include <TTreeReader.h>
+#include <TTreeReaderArray.h>
+#include <TTreeReaderValue.h>
 #include <exception>
 #include <iostream>
-#include <TTreeReader.h>
-#include <TTreeReaderValue.h>
-#include <TTreeReaderArray.h>
 
 // Headers needed by this particular selector
 #include <vector>
+#include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "Analysis/VVAnalysis/interface/helpers.h"
-#include "Analysis/VVAnalysis/interface/BranchManager.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 #include "PhysicsTools/HepMCCandAlgos/interface/PDFWeightsHelper.h"
 
 class NanoGenSelectorBase : public SelectorBase {
-public :
+   public:
     PDFWeightsHelper pdfweightshelper_;
     // Derived values
     reco::GenParticleCollection leptons;
@@ -66,14 +66,14 @@ public :
     TH1D* mcPdfWeights_;
     TH1D* hesPdfWeights_;
     TH1D* scaleWeights_;
-    
+
     double LHEHessianPdfWeight[N_MC2HESSIAN_WEIGHTS_];
     // Values read from file
-    TTreeReader     fReader;
+    TTreeReader fReader;
     TTreeReaderValue<Float_t> genWeight = {fReader, "genWeight"};
     TTreeReaderValue<UInt_t> nLHEScaleWeight = {fReader, "nLHEScaleWeight"};
     TTreeReaderArray<Float_t> LHEScaleWeight = {fReader, "LHEScaleWeight"};
-    
+
     UInt_t nLHEPdfWeight = 0;
     Float_t LHEPdfWeight[N_LHEPDF_WEIGHTS_];
     UInt_t nLHEScaleWeightAltSet1 = 0;
@@ -98,12 +98,18 @@ public :
     bool unknownWeightsAlt_ = false;
 
     TTreeReaderValue<UInt_t> nGenDressedLepton = {fReader, "nGenDressedLepton"};
-    TTreeReaderArray<Bool_t> GenDressedLepton_hasTauAnc = {fReader, "GenDressedLepton_hasTauAnc"};
-    TTreeReaderArray<Float_t> GenDressedLepton_pt = {fReader, "GenDressedLepton_pt"};
-    TTreeReaderArray<Float_t> GenDressedLepton_eta = {fReader, "GenDressedLepton_eta"};
-    TTreeReaderArray<Float_t> GenDressedLepton_phi = {fReader, "GenDressedLepton_phi"};
-    TTreeReaderArray<Float_t> GenDressedLepton_mass = {fReader, "GenDressedLepton_mass"};
-    TTreeReaderArray<Int_t> GenDressedLepton_pdgId = {fReader, "GenDressedLepton_pdgId"};
+    TTreeReaderArray<Bool_t> GenDressedLepton_hasTauAnc = {
+        fReader, "GenDressedLepton_hasTauAnc"};
+    TTreeReaderArray<Float_t> GenDressedLepton_pt = {fReader,
+                                                     "GenDressedLepton_pt"};
+    TTreeReaderArray<Float_t> GenDressedLepton_eta = {fReader,
+                                                      "GenDressedLepton_eta"};
+    TTreeReaderArray<Float_t> GenDressedLepton_phi = {fReader,
+                                                      "GenDressedLepton_phi"};
+    TTreeReaderArray<Float_t> GenDressedLepton_mass = {fReader,
+                                                       "GenDressedLepton_mass"};
+    TTreeReaderArray<Int_t> GenDressedLepton_pdgId = {fReader,
+                                                      "GenDressedLepton_pdgId"};
     TTreeReaderValue<UInt_t> nGenPart = {fReader, "nGenPart"};
     TTreeReaderArray<Float_t> GenPart_pt = {fReader, "GenPart_pt"};
     TTreeReaderArray<Float_t> GenPart_eta = {fReader, "GenPart_eta"};
@@ -111,7 +117,8 @@ public :
     TTreeReaderArray<Float_t> GenPart_mass = {fReader, "GenPart_mass"};
     TTreeReaderArray<Int_t> GenPart_pdgId = {fReader, "GenPart_pdgId"};
     TTreeReaderArray<Int_t> GenPart_status = {fReader, "GenPart_status"};
-    TTreeReaderArray<Int_t> GenPart_statusFlags = {fReader, "GenPart_statusFlags"};
+    TTreeReaderArray<Int_t> GenPart_statusFlags = {fReader,
+                                                   "GenPart_statusFlags"};
     TTreeReaderValue<UInt_t> nLHEPart = {fReader, "nLHEPart"};
     TTreeReaderArray<Float_t> LHEPart_pt = {fReader, "LHEPart_pt"};
     TTreeReaderArray<Float_t> LHEPart_eta = {fReader, "LHEPart_eta"};
@@ -123,35 +130,40 @@ public :
     TTreeReaderArray<Float_t> GenJet_eta = {fReader, "GenJet_eta"};
     TTreeReaderArray<Float_t> GenJet_phi = {fReader, "GenJet_phi"};
     TTreeReaderArray<Float_t> GenJet_mass = {fReader, "GenJet_mass"};
-    //TTreeReaderValue<Float_t> GenMET_pt = {fReader, "GenMET_pt"};
-    //TTreeReaderValue<Float_t> GenMET_phi = {fReader, "GenMET_phi"};
-    TTreeReaderValue<Float_t> MET_fiducialGenPt = {fReader, "MET_fiducialGenPt"};
-    TTreeReaderValue<Float_t> MET_fiducialGenPhi = {fReader, "MET_fiducialGenPhi"};
+    // TTreeReaderValue<Float_t> GenMET_pt = {fReader, "GenMET_pt"};
+    // TTreeReaderValue<Float_t> GenMET_phi = {fReader, "GenMET_phi"};
+    TTreeReaderValue<Float_t> MET_fiducialGenPt = {fReader,
+                                                   "MET_fiducialGenPt"};
+    TTreeReaderValue<Float_t> MET_fiducialGenPhi = {fReader,
+                                                    "MET_fiducialGenPhi"};
     float ht;
     float ptVlhe;
-    
+
     BranchManager b;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    NanoGenSelectorBase(TTree * /*tree*/ =0) { }
-    ~NanoGenSelectorBase() { }
-    virtual void    SetupNewDirectory() override;
+    virtual void Init(TTree* tree) override;
+    NanoGenSelectorBase(TTree* /*tree*/ = 0) {}
+    ~NanoGenSelectorBase() {}
+    virtual void SetupNewDirectory() override;
 
-    ClassDefOverride(NanoGenSelectorBase,0);
+    ClassDefOverride(NanoGenSelectorBase, 0);
 
-protected:
-    virtual void    SetBranchesNanoAOD() override;
-    virtual void    FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override {}
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+   protected:
+    virtual void SetBranchesNanoAOD() override;
+    virtual void FillHistograms(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override {
+    }
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     virtual void SetComposite() {}
-    bool overlapsCollection(const LorentzVector& cand, reco::GenParticleCollection& collection, const float deltaRCut, size_t maxCompare);
+    bool overlapsCollection(const LorentzVector& cand,
+                            reco::GenParticleCollection& collection,
+                            const float deltaRCut, size_t maxCompare);
     void buildHessian2MCSet();
-    reco::GenParticle makeGenParticle(int pdgid, int status, float pt, float eta, float phi, float m);
+    reco::GenParticle makeGenParticle(int pdgid, int status, float pt,
+                                      float eta, float phi, float m);
     double breitWignerWeight(double offset);
 };
 
 #endif
-
-
-

--- a/interface/ScaleFactor.h
+++ b/interface/ScaleFactor.h
@@ -1,59 +1,58 @@
 /* Scale Factor class for applying scale factors in ROOT hists etc.
  *
  * By N. Smith, U. Wisconsin
- * 
+ *
  */
 #ifndef ScaleFactors_h
 #define ScaleFactors_h
 
-#include "TROOT.h"
-#include "TObject.h"
 #include "TH1D.h"
 #include "TH2D.h"
+#include "TObject.h"
+#include "TROOT.h"
 
 // Streamable scale factor histogram object
 // Add the histogram after instantiating, then you
 // can pass it to proof, or save to file, or whatever
 class ScaleFactor : public TNamed {
-  public:
+   public:
     enum Variation {
-      CentralValue,
-      ShiftUp,
-      ShiftDown,
+        CentralValue,
+        ShiftUp,
+        ShiftDown,
     };
-    enum OverflowBehavior {
-      AsInHist,
-      NearestEntry,
-      Unity
-    };
+    enum OverflowBehavior { AsInHist, NearestEntry, Unity };
 
     ScaleFactor() {}
     ScaleFactor(const char *name, const char *title) : TNamed(name, title) {}
-    ScaleFactor(const TString &name, const TString &title) : TNamed(name, title) {}
+    ScaleFactor(const TString &name, const TString &title)
+        : TNamed(name, title) {}
     virtual ~ScaleFactor();
 
-    void Set1DHist(TH1D * central, TH1D * shiftUp=0, TH1D * shiftDown=0, OverflowBehavior b=Unity);
-    TH1D * Get1DHist(Variation var=CentralValue);
-    void Set2DHist(TH2D * central, TH2D * shiftUp=0, TH2D * shiftDown=0, OverflowBehavior b=Unity);
-    TH2D * Get2DHist(Variation var=CentralValue);
+    void Set1DHist(TH1D *central, TH1D *shiftUp = 0, TH1D *shiftDown = 0,
+                   OverflowBehavior b = Unity);
+    TH1D *Get1DHist(Variation var = CentralValue);
+    void Set2DHist(TH2D *central, TH2D *shiftUp = 0, TH2D *shiftDown = 0,
+                   OverflowBehavior b = Unity);
+    TH2D *Get2DHist(Variation var = CentralValue);
 
-    double Evaluate1D(double x, Variation var=CentralValue) const;
-    double Evaluate2D(double x, double y, Variation var=CentralValue) const;
+    double Evaluate1D(double x, Variation var = CentralValue) const;
+    double Evaluate2D(double x, double y, Variation var = CentralValue) const;
 
-    void RegisterGlobalFunction(int dimension=1);
+    void RegisterGlobalFunction(int dimension = 1);
 
-  private:
-    void SetOverflowBins(TH1D * hist, OverflowBehavior b);
-    void SetOverflowBins(TH2D * hist, OverflowBehavior b);
+   private:
+    void SetOverflowBins(TH1D *hist, OverflowBehavior b);
+    void SetOverflowBins(TH2D *hist, OverflowBehavior b);
 
-    TH1D * histCentral1D_{nullptr};
-    TH1D * histShiftUp1D_{nullptr};
-    TH1D * histShiftDown1D_{nullptr};
-    TH2D * histCentral2D_{nullptr};
-    TH2D * histShiftUp2D_{nullptr};
-    TH2D * histShiftDown2D_{nullptr};
+    TH1D *histCentral1D_{nullptr};
+    TH1D *histShiftUp1D_{nullptr};
+    TH1D *histShiftDown1D_{nullptr};
+    TH2D *histCentral2D_{nullptr};
+    TH2D *histShiftUp2D_{nullptr};
+    TH2D *histShiftDown2D_{nullptr};
 
-  ClassDef(ScaleFactor,1);
+    ClassDef(ScaleFactor, 1);
 };
 
 #endif

--- a/interface/SelectorBase.h
+++ b/interface/SelectorBase.h
@@ -1,105 +1,177 @@
 #ifndef SelectorBase_h
 #define SelectorBase_h
 
-#include <TROOT.h>
-#include <string.h>
 #include <TChain.h>
+#include <TEfficiency.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
 #include <TH3.h>
-#include <TEfficiency.h>
+#include <TROOT.h>
+#include <TSelector.h>
+#include <string.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
-#include <vector>
 #include <unordered_map>
+#include <vector>
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 
-#define PAIR(NAME_) {#NAME_, NAME_}
+#define PAIR(NAME_) \
+    { #NAME_, NAME_ }
 
 enum Channel {
-    e,           m,         
-    ep,          en,        mp,     mn,
-    ee,          em,        mm,     
-    eee,         eem,       emm,    mmm,
-    eeee,        eemm,      mmee,   mmmm,
-    Inclusive,   Unknown,   lll, all,
+    e,
+    m,
+    ep,
+    en,
+    mp,
+    mn,
+    ee,
+    em,
+    mm,
+    eee,
+    eem,
+    emm,
+    mmm,
+    eeee,
+    eemm,
+    mmee,
+    mmmm,
+    Inclusive,
+    Unknown,
+    lll,
+    all,
 };
-  
-enum Systematic {
-    Central=0,
-    jetEnergyScaleUp,          jetEnergyScaleDown,
-    jetEnergyResolutionUp,     jetEnergyResolutionDown,
-    metUnclusteredEnergyUp,    metUnclusteredEnergyDown,
-    muonEfficiencyUp,          muonEfficiencyDown,
-    muonScaleUp,               muonScaleDown,
-    electronEfficiencyUp,      electronEfficiencyDown,
-    electronScaleUp,           electronScaleDown,
-    pileupUp,                  pileupDown,
-    muonEfficiencyMCSubtractUp, muonEfficiencyMCSubtractDown, 
-    modelingFsrUp,             modelingFsrDown, 
-    muonEfficiencyBackgroundUp, muonEfficiencyBackgroundDown, 
-    muonEfficiencyTagPtUp,     muonEfficiencyTagPtDown, 
-    muonEfficiencyStatUp,      muonEfficiencyStatDown, 
-    recoilCorrectionEtaShapeUp,   recoilCorrectionEtaShapeDown,  
-    recoilCorrectionRUShapesUp,   recoilCorrectionRUShapesDown,  
-    recoilCorrectionKeysShapeUp,  recoilCorrectionKeysShapeDown, 
-    recoilCorrectionStat0Up,      recoilCorrectionStat0Down,     
-    recoilCorrectionStat1Up,      recoilCorrectionStat1Down,
-    recoilCorrectionStat2Up,      recoilCorrectionStat2Down,     
-    recoilCorrectionStat3Up,      recoilCorrectionStat3Down,     
-    recoilCorrectionStat4Up,      recoilCorrectionStat4Down,     
-    recoilCorrectionStat5Up,      recoilCorrectionStat5Down,     
-    recoilCorrectionStat6Up,      recoilCorrectionStat6Down,     
-    recoilCorrectionStat7Up,      recoilCorrectionStat7Down,     
-    recoilCorrectionStat8Up,      recoilCorrectionStat8Down,     
-    recoilCorrectionStat9Up,      recoilCorrectionStat9Down,     
-    BareLeptons, BornParticles, LHEParticles,
-    mWShift100MeVUp, mWShift50MeVUp, mWShift25MeVUp, mWShift20MeVUp, mWShift10MeVUp, 
-    mWShift100MeVDown, mWShift50MeVDown, mWShift25MeVDown, mWShift20MeVDown, mWShift10MeVDown, 
-    mZShift100MeVUp, mZShift50MeVUp, mZShift25MeVUp, mZShift20MeVUp, mZShift10MeVUp, 
-    mZShift100MeVDown, mZShift50MeVDown, mZShift25MeVDown, mZShift20MeVDown, mZShift10MeVDown, 
-    ptV0to3, ptV3to5, ptV5to7, ptV7to9, ptV9to12, ptV12to15, ptV15to20, ptV20to27, ptV27to40, ptV40toInf,
-    ptV0to3_lhe, ptV3to5_lhe, ptV5to7_lhe, ptV7to9_lhe, ptV9to12_lhe, ptV12to15_lhe, 
-    ptV15to20_lhe, ptV20to27_lhe, ptV27to40_lhe, ptV40toInf_lhe,
-}; 
 
-    
+enum Systematic {
+    Central = 0,
+    jetEnergyScaleUp,
+    jetEnergyScaleDown,
+    jetEnergyResolutionUp,
+    jetEnergyResolutionDown,
+    metUnclusteredEnergyUp,
+    metUnclusteredEnergyDown,
+    muonEfficiencyUp,
+    muonEfficiencyDown,
+    muonScaleUp,
+    muonScaleDown,
+    electronEfficiencyUp,
+    electronEfficiencyDown,
+    electronScaleUp,
+    electronScaleDown,
+    pileupUp,
+    pileupDown,
+    muonEfficiencyMCSubtractUp,
+    muonEfficiencyMCSubtractDown,
+    modelingFsrUp,
+    modelingFsrDown,
+    muonEfficiencyBackgroundUp,
+    muonEfficiencyBackgroundDown,
+    muonEfficiencyTagPtUp,
+    muonEfficiencyTagPtDown,
+    muonEfficiencyStatUp,
+    muonEfficiencyStatDown,
+    recoilCorrectionEtaShapeUp,
+    recoilCorrectionEtaShapeDown,
+    recoilCorrectionRUShapesUp,
+    recoilCorrectionRUShapesDown,
+    recoilCorrectionKeysShapeUp,
+    recoilCorrectionKeysShapeDown,
+    recoilCorrectionStat0Up,
+    recoilCorrectionStat0Down,
+    recoilCorrectionStat1Up,
+    recoilCorrectionStat1Down,
+    recoilCorrectionStat2Up,
+    recoilCorrectionStat2Down,
+    recoilCorrectionStat3Up,
+    recoilCorrectionStat3Down,
+    recoilCorrectionStat4Up,
+    recoilCorrectionStat4Down,
+    recoilCorrectionStat5Up,
+    recoilCorrectionStat5Down,
+    recoilCorrectionStat6Up,
+    recoilCorrectionStat6Down,
+    recoilCorrectionStat7Up,
+    recoilCorrectionStat7Down,
+    recoilCorrectionStat8Up,
+    recoilCorrectionStat8Down,
+    recoilCorrectionStat9Up,
+    recoilCorrectionStat9Down,
+    BareLeptons,
+    BornParticles,
+    LHEParticles,
+    mWShift100MeVUp,
+    mWShift50MeVUp,
+    mWShift25MeVUp,
+    mWShift20MeVUp,
+    mWShift10MeVUp,
+    mWShift100MeVDown,
+    mWShift50MeVDown,
+    mWShift25MeVDown,
+    mWShift20MeVDown,
+    mWShift10MeVDown,
+    mZShift100MeVUp,
+    mZShift50MeVUp,
+    mZShift25MeVUp,
+    mZShift20MeVUp,
+    mZShift10MeVUp,
+    mZShift100MeVDown,
+    mZShift50MeVDown,
+    mZShift25MeVDown,
+    mZShift20MeVDown,
+    mZShift10MeVDown,
+    ptV0to3,
+    ptV3to5,
+    ptV5to7,
+    ptV7to9,
+    ptV9to12,
+    ptV12to15,
+    ptV15to20,
+    ptV20to27,
+    ptV27to40,
+    ptV40toInf,
+    ptV0to3_lhe,
+    ptV3to5_lhe,
+    ptV5to7_lhe,
+    ptV7to9_lhe,
+    ptV9to12_lhe,
+    ptV12to15_lhe,
+    ptV15to20_lhe,
+    ptV20to27_lhe,
+    ptV27to40_lhe,
+    ptV40toInf_lhe,
+};
+
 struct HistLabel {
     std::string name;
     Channel channel;
     Systematic variation;
 
     bool operator==(const HistLabel& h) const {
-        return (name == h.name &&
-            channel == h.channel &&
-            variation == h.variation);
+        return (name == h.name && channel == h.channel &&
+                variation == h.variation);
     };
 };
 
-namespace std
-{
-    template <>
-    struct hash<HistLabel>
-    {
-        size_t operator()(const HistLabel& h) const
-        {
-            return (std::hash<std::string>()(h.name) ^ std::hash<size_t>()(h.channel) ^
+namespace std {
+template <>
+struct hash<HistLabel> {
+    size_t operator()(const HistLabel& h) const {
+        return (std::hash<std::string>()(h.name) ^
+                std::hash<size_t>()(h.channel) ^
                 std::hash<size_t>()(h.variation));
-
-        }
-    };
-}
+    }
+};
+}  // namespace std
 
 class SelectorBase : public TSelector {
- public :
+   public:
     std::map<std::string, ScaleFactor*> scaleFactors;
     TEfficiency* prefireEff_;
-    
-    TTree          *fChain = 0;   //!pointer to the analyzed TTree or TChain
+
+    TTree* fChain = 0;  //! pointer to the analyzed TTree or TChain
 
     /*********************************/
     /*  _____ _   _ _   _ __  __      */
@@ -108,7 +180,7 @@ class SelectorBase : public TSelector {
     /* | |___| |\  | |_| | |  | \__ \ */
     /* |_____|_| \_|\___/|_|  |_|___/ */
     /*********************************/
-                              
+
     enum NtupleType {
         NanoAOD,
         UWVV,
@@ -116,26 +188,38 @@ class SelectorBase : public TSelector {
     };
 
     enum Selection {
-        Default,                      None,
-        tightleptons,                 ZZGenFiducial,
-        Wselection,                   Zselection,
-        WselectionAntiIso,                   
-        Wselection_Full,              FakeRateSelectionLoose,
-        FakeRateSelectionTight,       VBSselection_Loose,
-        VBSselection_NoZeppenfeld,    VBSselection_Tight,
-        VBSselection_Loose_Full,      VBSselection_NoZeppenfeld_Full,
-        VBSselection_Tight_Full,      VBSBackgroundControl,
-        VBSBackgroundControlATLAS,    VBSBackgroundControl_Full,
-        VBSBackgroundControlLoose,    VBSBackgroundControlLoose_Full,
-        Inclusive2Jet,                Inclusive2Jet_Full,
-        TightWithLooseVeto,           FourTopPlots,
-        FourTopCutBasedEl,            FourTopMVAEl,
-        BEfficiency,                  test,
+        Default,
+        None,
+        tightleptons,
+        ZZGenFiducial,
+        Wselection,
+        Zselection,
+        WselectionAntiIso,
+        Wselection_Full,
+        FakeRateSelectionLoose,
+        FakeRateSelectionTight,
+        VBSselection_Loose,
+        VBSselection_NoZeppenfeld,
+        VBSselection_Tight,
+        VBSselection_Loose_Full,
+        VBSselection_NoZeppenfeld_Full,
+        VBSselection_Tight_Full,
+        VBSBackgroundControl,
+        VBSBackgroundControlATLAS,
+        VBSBackgroundControl_Full,
+        VBSBackgroundControlLoose,
+        VBSBackgroundControlLoose_Full,
+        Inclusive2Jet,
+        Inclusive2Jet_Full,
+        TightWithLooseVeto,
+        FourTopPlots,
+        FourTopCutBasedEl,
+        FourTopMVAEl,
+        BEfficiency,
+        test,
     };
 
-    enum Year {
-        yrdefault,      yr2016,      yr2017,      yr2018
-    };
+    enum Year { yrdefault, yr2016, yr2017, yr2018 };
 
     typedef std::pair<Channel, std::string> ChannelPair;
 
@@ -178,10 +262,10 @@ class SelectorBase : public TSelector {
         {"VBSBackgroundControlLoose_Full", VBSBackgroundControlLoose_Full},
         {"Inclusive2Jet", Inclusive2Jet},
         {"Inclusive2Jet_Full", Inclusive2Jet_Full},
-        {"TightWithLooseVeto", TightWithLooseVeto}, 
+        {"TightWithLooseVeto", TightWithLooseVeto},
         {"FourTopPlots", FourTopPlots},
         {"FourTopCutBasedEl", FourTopCutBasedEl},
-	{"FourTopMVAEl", FourTopMVAEl}, 
+        {"FourTopMVAEl", FourTopMVAEl},
     };
 
     std::map<std::string, Year> yearMap_ = {
@@ -190,22 +274,22 @@ class SelectorBase : public TSelector {
         {"2017", yr2017},
         {"2018", yr2018},
     };
-    
-    std::map<std::string, Channel> channelMap_ = {
-        {"e", e},                   {"m", m},         
-        {"ep", ep},                 {"mp", mp},       {"ep", ep},       {"mn", mn},  
-        {"ee", ee},                 {"em", em},       {"mm", mm},
-        {"eee", eee},               {"eem", eem},     {"emm", emm},     {"mmm", mmm},
-        {"eeee", eeee},             {"eemm", eemm},   {"mmee", mmee},   {"mmmm", mmmm},
-        {"Inclusive", Inclusive},   {"lll", lll},     {"all", all},
-    };
 
+    std::map<std::string, Channel> channelMap_ = {
+        {"e", e},       {"m", m},       {"ep", ep},
+        {"mp", mp},     {"ep", ep},     {"mn", mn},
+        {"ee", ee},     {"em", em},     {"mm", mm},
+        {"eee", eee},   {"eem", eem},   {"emm", emm},
+        {"mmm", mmm},   {"eeee", eeee}, {"eemm", eemm},
+        {"mmee", mmee}, {"mmmm", mmmm}, {"Inclusive", Inclusive},
+        {"lll", lll},   {"all", all},
+    };
 
     std::vector<ChannelPair> allChannels_ = {};
     SystMap variations_ = {{Central, {}}};
     SystMap systematics_ = {};
 
-    TList *currentHistDir_{nullptr};
+    TList* currentHistDir_{nullptr};
     TH1D* sumWeightsHist_;
 
     std::vector<std::string> subprocesses_;
@@ -213,24 +297,26 @@ class SelectorBase : public TSelector {
     bool isNonprompt_ = false;
     bool applyScaleFactors_;
     bool applyPrefiringCorr_;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    SelectorBase(TTree * /*tree*/ =0) { }
-    virtual ~SelectorBase() { }
-    virtual void    SetScaleFactors();
-    virtual Int_t   Version() const { return 2; }
-    virtual void    Begin(TTree *tree);
-    virtual void    SlaveBegin(TTree *tree);
-    virtual void    Init(TTree *tree);
-    virtual Bool_t  Notify();
-    virtual Bool_t  Process(Long64_t entry);
-    virtual Int_t   GetEntry(Long64_t entry, Int_t getall = 0) { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
-    virtual void    SetOption(const char *option) { fOption = option; }
-    virtual void    SetObject(TObject *obj) { fObject = obj; }
-    virtual void    SetInputList(TList *input) { fInput = input; }
-    virtual TList  *GetOutputList() const { return fOutput; }
-    virtual void    SlaveTerminate();
-    virtual void    Terminate();
+    SelectorBase(TTree* /*tree*/ = 0) {}
+    virtual ~SelectorBase() {}
+    virtual void SetScaleFactors();
+    virtual Int_t Version() const { return 2; }
+    virtual void Begin(TTree* tree);
+    virtual void SlaveBegin(TTree* tree);
+    virtual void Init(TTree* tree);
+    virtual Bool_t Notify();
+    virtual Bool_t Process(Long64_t entry);
+    virtual Int_t GetEntry(Long64_t entry, Int_t getall = 0) {
+        return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0;
+    }
+    virtual void SetOption(const char* option) { fOption = option; }
+    virtual void SetObject(TObject* obj) { fObject = obj; }
+    virtual void SetInputList(TList* input) { fInput = input; }
+    virtual TList* GetOutputList() const { return fOutput; }
+    virtual void SlaveTerminate();
+    virtual void Terminate();
 
     // We'll collect pointers to objects from derived classes
     // as they are registered with AddObject, and update them to
@@ -239,53 +325,53 @@ class SelectorBase : public TSelector {
     // Derived classes override (and call) this to register new objects
     // With AddObject<Type>(localPtr, ...);
     virtual void SetupNewDirectory();
-    void    SetBranches();
-    void    LoadBranches(Long64_t entry, SystPair variation);
-    virtual void    SetBranchesNanoAOD() {
+    void SetBranches();
+    void LoadBranches(Long64_t entry, SystPair variation);
+    virtual void SetBranchesNanoAOD() {
         throw std::domain_error("NanoAOD ntuples not supported for selector!");
     }
-    virtual void    LoadBranchesNanoAOD(Long64_t entry, SystPair variation) {
+    virtual void LoadBranchesNanoAOD(Long64_t entry, SystPair variation) {
         throw std::domain_error("NanoAOD ntuples not supported for selector!");
     }
-    virtual void    SetBranchesUWVV() {
+    virtual void SetBranchesUWVV() {
         throw std::domain_error("UWVV ntuples not supported for selector!");
     }
-    virtual void    LoadBranchesUWVV(Long64_t entry, SystPair variation) { 
+    virtual void LoadBranchesUWVV(Long64_t entry, SystPair variation) {
         throw std::domain_error("UWVV ntuples not supported for selector!");
     }
-    virtual void    SetBranchesBacon() {
+    virtual void SetBranchesBacon() {
         throw std::domain_error("Bacon ntuples not supported for selector!");
     }
-    virtual void    LoadBranchesBacon(Long64_t entry, SystPair variation) {
+    virtual void LoadBranchesBacon(Long64_t entry, SystPair variation) {
         throw std::domain_error("Bacon ntuples not supported for selector!");
     }
-    virtual void    FillHistograms(Long64_t entry, SystPair variation) { }
+    virtual void FillHistograms(Long64_t entry, SystPair variation) {}
     void addSubprocesses(std::vector<std::string> processes);
     void makeOutputDirs();
     void setSubprocesses(std::string process);
 
-
-
-    template<typename T, typename... Args>
-	void AddObject(T* &ptr, Args... args) {
-	static_assert(std::is_base_of<TNamed, T>::value, "Objects must inheirit from ROOT TNamed to be streamable from PROOF sessions");
-	ptr = new T(args...);
-	ptr->SetDirectory(gROOT);
-	currentHistDir_->Add(ptr);
-	allObjects_.insert((TNamed**) &ptr);
+    template <typename T, typename... Args>
+    void AddObject(T*& ptr, Args... args) {
+        static_assert(std::is_base_of<TNamed, T>::value,
+                      "Objects must inheirit from ROOT TNamed to be streamable "
+                      "from PROOF sessions");
+        ptr = new T(args...);
+        ptr->SetDirectory(gROOT);
+        currentHistDir_->Add(ptr);
+        allObjects_.insert((TNamed**)&ptr);
     };
-    
-    void UpdateDirectory();    
-    ClassDef(SelectorBase,0);
 
- protected:
+    void UpdateDirectory();
+    ClassDef(SelectorBase, 0);
+
+   protected:
     // Maps to the histogram pointers themselves
     HistMap1D histMap1D_ = {};
     std::unordered_map<std::string, HistMap1D> subprocessHistMaps1D_ = {};
     std::vector<HistMap2D> subprocessWeightHistMaps1D_ = {};
     HistMap2D histMap2D_ = {};
     HistMap2D weighthistMap1D_ = {};
-    HistMap3D weighthistMap2D_ {};
+    HistMap3D weighthistMap2D_{};
 
     std::vector<std::string> hists1D_ = {};
     std::vector<std::string> hists2D_ = {};
@@ -306,48 +392,54 @@ class SelectorBase : public TSelector {
     Year year_ = yrdefault;
     bool isMC_;
 
-    
-    float GetPrefiringEfficiencyWeight(std::vector<float>* jetPt, std::vector<float>* jetEta);
+    float GetPrefiringEfficiencyWeight(std::vector<float>* jetPt,
+                                       std::vector<float>* jetEta);
     virtual std::string GetNameFromFile() { return ""; }
-    void InitializeHistogramFromConfig(std::string name, ChannelPair channel, std::vector<std::string>& histData);
+    void InitializeHistogramFromConfig(std::string name, ChannelPair channel,
+                                       std::vector<std::string>& histData);
     void InitializeHistogramsFromConfig();
     std::vector<std::string> ReadHistDataFromConfig(std::string histDataString);
     std::string concatenateNames(const char* baseName, std::string& toAppend);
-    std::string concatenateNames(const std::string& baseName, const char* toAppend);
-    std::string concatenateNames(const std::string& baseName, std::string& toAppend);
+    std::string concatenateNames(const std::string& baseName,
+                                 const char* toAppend);
+    std::string concatenateNames(const std::string& baseName,
+                                 std::string& toAppend);
     std::string getHistName(std::string histName, std::string variationName);
-    std::string getHistName(std::string histName, std::string variationName, std::string channel);
-    template<typename T>
-    void InitializeHistMap(std::vector<std::string>& labels, std::unordered_map<HistLabel, T*>& histMap);
+    std::string getHistName(std::string histName, std::string variationName,
+                            std::string channel);
+    template <typename T>
+    void InitializeHistMap(std::vector<std::string>& labels,
+                           std::unordered_map<HistLabel, T*>& histMap);
 
     // Filling Functions
-    template<typename T, typename... Args>
-	void SafeHistFill(std::unordered_map<HistLabel, T*>& container, 
-		std::string name, Channel chan, Systematic var, Args... args) {
+    template <typename T, typename... Args>
+    void SafeHistFill(std::unordered_map<HistLabel, T*>& container,
+                      std::string name, Channel chan, Systematic var,
+                      Args... args) {
         SafeHistFill(container, name.c_str(), chan, var, args...);
     }
 
-    template<typename T, typename... Args>
-	void SafeHistFill(std::unordered_map<HistLabel, T*>& container, 
-		const char* name, Channel chan, Systematic var, Args... args) {
+    template <typename T, typename... Args>
+    void SafeHistFill(std::unordered_map<HistLabel, T*>& container,
+                      const char* name, Channel chan, Systematic var,
+                      Args... args) {
         HistLabel histLabel = {name, chan, var};
         if (container[histLabel] != nullptr)
             container[histLabel]->Fill(args...);
     };
-  
-    template<typename T, typename... Args>
-	void HistFullFill(std::unordered_map<HistLabel, T*>& container,
-			  const char* histname, Systematic var, Args... args) {
-	    SafeHistFill(container, histname, channel_, var, args...);
-	    SafeHistFill(container, histname, all, var, args...);
+
+    template <typename T, typename... Args>
+    void HistFullFill(std::unordered_map<HistLabel, T*>& container,
+                      const char* histname, Systematic var, Args... args) {
+        SafeHistFill(container, histname, channel_, var, args...);
+        SafeHistFill(container, histname, all, var, args...);
     }
-    template<typename T, typename... Args>
-	void HistFullFill(std::unordered_map<HistLabel, T*>& container,
-			  const std::string& histname, Systematic var, Args... args) {
+    template <typename T, typename... Args>
+    void HistFullFill(std::unordered_map<HistLabel, T*>& container,
+                      const std::string& histname, Systematic var,
+                      Args... args) {
         HistFullFill(container, histname.c_str(), var, args...);
     }
-  
 };
 
 #endif
-

--- a/interface/TTTSelector.h
+++ b/interface/TTTSelector.h
@@ -1,149 +1,151 @@
 #ifndef TTTSelector_h
 #define TTTSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
+#include <TEfficiency.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TEfficiency.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/GoodParticle.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> LorentzVector;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
 class TTTSelector : public SelectorBase {
- public :
-  /*****************************************/
-  /* ____  ____   ___  __  __   ___ __  __ */
-  /* || )) || \\ // \\ ||\ ||  //   ||  || */
-  /* ||=)  ||_// ||=|| ||\\|| ((    ||==|| */
-  /* ||_)) || \\ || || || \||  \\__ ||  || */
-  /*****************************************/
-  
-  ScaleFactor* pileupSF_;
-  ScaleFactor* muonSF_;
-  ScaleFactor* eIdSF_ ;
-  ScaleFactor* eGsfSF_;
-  ScaleFactor* mIdSF_;
-  ScaleFactor* mIsoSF_;
+   public:
+    /*****************************************/
+    /* ____  ____   ___  __  __   ___ __  __ */
+    /* || )) || \\ // \\ ||\ ||  //   ||  || */
+    /* ||=)  ||_// ||=|| ||\\|| ((    ||==|| */
+    /* ||_)) || \\ || || || \||  \\__ ||  || */
+    /*****************************************/
 
-  // Common variables
-  Float_t genWeight;
-  Float_t MET;
-  Float_t type1_pfMETPhi;
+    ScaleFactor* pileupSF_;
+    ScaleFactor* muonSF_;
+    ScaleFactor* eIdSF_;
+    ScaleFactor* eGsfSF_;
+    ScaleFactor* mIdSF_;
+    ScaleFactor* mIsoSF_;
 
-  //NanoAOD variables
-  static const unsigned int N_KEEP_MU_E_ = 15;
-  static const unsigned int N_KEEP_JET_ = 35;
+    // Common variables
+    Float_t genWeight;
+    Float_t MET;
+    Float_t type1_pfMETPhi;
 
-  UInt_t nElectron;
-  Float_t Electron_pt[N_KEEP_MU_E_];
-  Float_t Electron_eta[N_KEEP_MU_E_];
-  Float_t Electron_phi[N_KEEP_MU_E_];
-  Float_t Electron_mass[N_KEEP_MU_E_];
-  Int_t Electron_cutBased[N_KEEP_MU_E_];
-  Int_t Electron_charge[N_KEEP_MU_E_];
-  Float_t Electron_MVA[N_KEEP_MU_E_];
-  Float_t Electron_miniPFRelIso_all[N_KEEP_MU_E_];
-  Float_t Electron_dxy[N_KEEP_MU_E_];
-  Float_t Electron_dz[N_KEEP_MU_E_];
-  Float_t Electron_sip3d[N_KEEP_MU_E_];
+    // NanoAOD variables
+    static const unsigned int N_KEEP_MU_E_ = 15;
+    static const unsigned int N_KEEP_JET_ = 35;
 
-  
-  UInt_t nMuon;
-  Float_t Muon_pt[N_KEEP_MU_E_];
-  Float_t Muon_eta[N_KEEP_MU_E_];
-  Float_t Muon_phi[N_KEEP_MU_E_];
-  Float_t Muon_mass[N_KEEP_MU_E_];
-  Int_t Muon_charge[N_KEEP_MU_E_];
-  Bool_t Muon_tightId[N_KEEP_MU_E_];
-  Bool_t Muon_mediumId[N_KEEP_MU_E_];
-  UChar_t Muon_tkIsoId[N_KEEP_MU_E_];
-  Float_t Muon_pfRelIso04_all[N_KEEP_MU_E_];
-  Float_t Muon_miniPFRelIso_all[N_KEEP_MU_E_];
-  Float_t Muon_dxy[N_KEEP_MU_E_];
-  Float_t Muon_dz[N_KEEP_MU_E_];
-  Float_t Muon_sip3d[N_KEEP_MU_E_];
+    UInt_t nElectron;
+    Float_t Electron_pt[N_KEEP_MU_E_];
+    Float_t Electron_eta[N_KEEP_MU_E_];
+    Float_t Electron_phi[N_KEEP_MU_E_];
+    Float_t Electron_mass[N_KEEP_MU_E_];
+    Int_t Electron_cutBased[N_KEEP_MU_E_];
+    Int_t Electron_charge[N_KEEP_MU_E_];
+    Float_t Electron_MVA[N_KEEP_MU_E_];
+    Float_t Electron_miniPFRelIso_all[N_KEEP_MU_E_];
+    Float_t Electron_dxy[N_KEEP_MU_E_];
+    Float_t Electron_dz[N_KEEP_MU_E_];
+    Float_t Electron_sip3d[N_KEEP_MU_E_];
 
-  Int_t numPU;
+    UInt_t nMuon;
+    Float_t Muon_pt[N_KEEP_MU_E_];
+    Float_t Muon_eta[N_KEEP_MU_E_];
+    Float_t Muon_phi[N_KEEP_MU_E_];
+    Float_t Muon_mass[N_KEEP_MU_E_];
+    Int_t Muon_charge[N_KEEP_MU_E_];
+    Bool_t Muon_tightId[N_KEEP_MU_E_];
+    Bool_t Muon_mediumId[N_KEEP_MU_E_];
+    UChar_t Muon_tkIsoId[N_KEEP_MU_E_];
+    Float_t Muon_pfRelIso04_all[N_KEEP_MU_E_];
+    Float_t Muon_miniPFRelIso_all[N_KEEP_MU_E_];
+    Float_t Muon_dxy[N_KEEP_MU_E_];
+    Float_t Muon_dz[N_KEEP_MU_E_];
+    Float_t Muon_sip3d[N_KEEP_MU_E_];
 
-  UInt_t nJet;
-  Float_t Jet_btagCSVV2[N_KEEP_JET_];
-  Float_t Jet_btagDeepB[N_KEEP_JET_];
-  Float_t Jet_eta[N_KEEP_JET_];
-  Float_t Jet_phi[N_KEEP_JET_];
-  Float_t Jet_pt[N_KEEP_JET_];
-  Float_t Jet_mass[N_KEEP_JET_];
-  Float_t Jet_neHEF[N_KEEP_JET_];
-  Float_t Jet_neEmEF[N_KEEP_JET_];
-  Int_t Jet_nConstituents[N_KEEP_JET_];
-  Float_t Jet_chHEF[N_KEEP_JET_];  
-  Float_t Jet_chEmEF[N_KEEP_JET_]; 
+    Int_t numPU;
 
-  ClassDefOverride(TTTSelector,0);
+    UInt_t nJet;
+    Float_t Jet_btagCSVV2[N_KEEP_JET_];
+    Float_t Jet_btagDeepB[N_KEEP_JET_];
+    Float_t Jet_eta[N_KEEP_JET_];
+    Float_t Jet_phi[N_KEEP_JET_];
+    Float_t Jet_pt[N_KEEP_JET_];
+    Float_t Jet_mass[N_KEEP_JET_];
+    Float_t Jet_neHEF[N_KEEP_JET_];
+    Float_t Jet_neEmEF[N_KEEP_JET_];
+    Int_t Jet_nConstituents[N_KEEP_JET_];
+    Float_t Jet_chHEF[N_KEEP_JET_];
+    Float_t Jet_chEmEF[N_KEEP_JET_];
 
-  /*******************************************************/
-  /* __ __  ___  ____  __  ___  ____  __     ____  __    */
-  /* || || // \\ || \\ || // \\ || )) ||    ||    (( \   */
-  /* \\ // ||=|| ||_// || ||=|| ||=)  ||    ||==   \\    */
-  /*  \V/  || || || \\ || || || ||_)) ||__| ||___ \_))   */
-  /*******************************************************/
-  
-  Float_t weight;
-  BranchManager b;
-  std::vector<GoodPart> goodParts;
-  std::vector<int> charge;
-  double HT;
-  int nTightJet, nBJets;
+    ClassDefOverride(TTTSelector, 0);
 
-  /************************************************************/
-  /* _____ __ __ __  __   ___ ______ __   ___   __  __  __    */
-  /* ||    || || ||\ ||  //   | || | ||  // \\  ||\ || (( \   */
-  /* ||==  || || ||\\|| ((      ||   || ((   )) ||\\||  \\    */
-  /* ||    \\_// || \||  \\__   ||   ||  \\_//  || \|| \_))   */
-  /************************************************************/
-  
-  /// Captial I for particle definition
-  bool IsGoodMuon(size_t);
-  bool IsGoodCBElectron(size_t);
-  bool IsGoodJet(size_t);
-  bool IsGoodBJet(size_t);
-  bool IsGoodMVAElectron2016(size_t);
-  bool IsGoodMVAElectron2017(size_t);
+    /*******************************************************/
+    /* __ __  ___  ____  __  ___  ____  __     ____  __    */
+    /* || || // \\ || \\ || // \\ || )) ||    ||    (( \   */
+    /* \\ // ||=|| ||_// || ||=|| ||=)  ||    ||==   \\    */
+    /*  \V/  || || || \\ || || || ||_)) ||__| ||___ \_))   */
+    /*******************************************************/
 
-  // lowercase I for helper function (kinda shitty convention, may change)
-  bool isLooseJetId(size_t);
-  bool isTightJetId(size_t);
-  bool isOverlap(size_t);
-  bool passFullIso(LorentzVector&, int, int);
+    Float_t weight;
+    BranchManager b;
+    std::vector<GoodPart> goodParts;
+    std::vector<int> charge;
+    double HT;
+    int nTightJet, nBJets;
 
-  //// General Functions
-  int getSRBin();
-  void clearValues();
-  void ApplyScaleFactors();
+    /************************************************************/
+    /* _____ __ __ __  __   ___ ______ __   ___   __  __  __    */
+    /* ||    || || ||\ ||  //   | || | ||  // \\  ||\ || (( \   */
+    /* ||==  || || ||\\|| ((      ||   || ((   )) ||\\||  \\    */
+    /* ||    \\_// || \||  \\__   ||   ||  \\_//  || \|| \_))   */
+    /************************************************************/
 
-  // Overloaded or necesary functions
-  virtual void    SetBranchesNanoAOD() override;
-  void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-  void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-  virtual void    SetupNewDirectory() override;
-  // Readers to access the data (delete the ones you do not need).
-  virtual void    SlaveBegin(TTree *tree) override;
-  virtual void    Init(TTree *tree) override;
+    /// Captial I for particle definition
+    bool IsGoodMuon(size_t);
+    bool IsGoodCBElectron(size_t);
+    bool IsGoodJet(size_t);
+    bool IsGoodBJet(size_t);
+    bool IsGoodMVAElectron2016(size_t);
+    bool IsGoodMVAElectron2017(size_t);
 
-  ///ignore
-  void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-  virtual void    SetBranchesUWVV() override;
+    // lowercase I for helper function (kinda shitty convention, may change)
+    bool isLooseJetId(size_t);
+    bool isTightJetId(size_t);
+    bool isOverlap(size_t);
+    bool passFullIso(LorentzVector&, int, int);
+
+    //// General Functions
+    int getSRBin();
+    void clearValues();
+    void ApplyScaleFactors();
+
+    // Overloaded or necesary functions
+    virtual void SetBranchesNanoAOD() override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
+    virtual void SetupNewDirectory() override;
+    // Readers to access the data (delete the ones you do not need).
+    virtual void SlaveBegin(TTree* tree) override;
+    virtual void Init(TTree* tree) override;
+
+    /// ignore
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void SetBranchesUWVV() override;
 };
 
 #endif
-

--- a/interface/ThreeLepSelector.h
+++ b/interface/ThreeLepSelector.h
@@ -3,11 +3,11 @@
 
 // #include <TROOT.h>
 #include <TChain.h>
+#include <TEfficiency.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TEfficiency.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 #include <map>
@@ -15,21 +15,28 @@
 #include <vector>
 
 // Headers needed by this particular selector
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/GoodParticle.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 
 #include "CondFormats/BTauObjects/interface/BTagCalibration.h"
 #include "CondTools/BTau/interface/BTagCalibrationReader.h"
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> LorentzVector;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
-enum PID {PID_MUON = 13, PID_ELECTRON = 11, PID_BJET = 5, PID_CJET = 4, PID_JET};
+enum PID {
+    PID_MUON = 13,
+    PID_ELECTRON = 11,
+    PID_BJET = 5,
+    PID_CJET = 4,
+    PID_JET
+};
 
 class ThreeLepSelector : public SelectorBase {
-public :
-   #include "Analysis/VVAnalysis/interface/FourTopScales.h"
-    
+   public:
+#include "Analysis/VVAnalysis/interface/FourTopScales.h"
+
     /*****************************************/
     /* ____  ____   ___  __  __   ___ __  __ */
     /* || )) || \\ // \\ ||\ ||  //   ||  || */
@@ -39,7 +46,7 @@ public :
 
     ScaleFactor* pileupSF_;
     ScaleFactor* muonSF_;
-    ScaleFactor* eIdSF_ ;
+    ScaleFactor* eIdSF_;
     ScaleFactor* eGsfSF_;
     ScaleFactor* mIdSF_;
     ScaleFactor* mIsoSF_;
@@ -49,81 +56,79 @@ public :
     Float_t MET;
     Float_t type1_pfMETPhi;
 
-    //NanoAOD variables
+    // NanoAOD variables
     static const unsigned int N_KEEP_MU_E_ = 15;
     static const unsigned int N_KEEP_JET_ = 35;
     static const unsigned int N_KEEP_GEN_ = 300;
 
-    
-    UInt_t    nElectron;
-    Float_t   Electron_pt[N_KEEP_MU_E_];
-    Float_t   Electron_eta[N_KEEP_MU_E_];
-    Float_t   Electron_phi[N_KEEP_MU_E_];
-    Float_t   Electron_mass[N_KEEP_MU_E_];
-    Int_t     Electron_cutBased[N_KEEP_MU_E_];
-    Int_t     Electron_charge[N_KEEP_MU_E_];
-    Float_t   Electron_MVA[N_KEEP_MU_E_];
-    Float_t   Electron_miniPFRelIso_all[N_KEEP_MU_E_];
-    Float_t   Electron_dxy[N_KEEP_MU_E_];
-    Float_t   Electron_dz[N_KEEP_MU_E_];
-    Float_t   Electron_sip3d[N_KEEP_MU_E_];
-    Bool_t    Electron_convVeto[N_KEEP_MU_E_];
-    UChar_t   Electron_lostHits[N_KEEP_MU_E_];
-    Int_t     Electron_tightCharge[N_KEEP_MU_E_];
-    Float_t   Electron_sieie[N_KEEP_MU_E_];
-    Float_t   Electron_hoe[N_KEEP_MU_E_];
-    Float_t   Electron_deltaEtaSC[N_KEEP_MU_E_];
-    Float_t   Electron_eInvMinusPInv[N_KEEP_MU_E_];
-    Float_t   Electron_dr03EcalRecHitSumEt[N_KEEP_MU_E_];
-    Float_t   Electron_dr03HcalDepth1TowerSumEt[N_KEEP_MU_E_];
-    Float_t   Electron_dr03TkSumPt[N_KEEP_MU_E_];
-    Int_t     Electron_vidBitmap[N_KEEP_MU_E_];
-    Float_t   Electron_jetRelIso[N_KEEP_MU_E_];
-    Float_t   Electron_eCorr[N_KEEP_MU_E_];
-  
-    UInt_t    nMuon;
-    Float_t   Muon_pt[N_KEEP_MU_E_];
-    Float_t   Muon_eta[N_KEEP_MU_E_];
-    Float_t   Muon_phi[N_KEEP_MU_E_];
-    Float_t   Muon_mass[N_KEEP_MU_E_];
-    Int_t     Muon_charge[N_KEEP_MU_E_];
-    Bool_t    Muon_tightId[N_KEEP_MU_E_];
-    Bool_t    Muon_mediumId[N_KEEP_MU_E_];
-    UChar_t   Muon_tkIsoId[N_KEEP_MU_E_];
-    Float_t   Muon_pfRelIso04_all[N_KEEP_MU_E_];
-    Float_t   Muon_miniPFRelIso_all[N_KEEP_MU_E_];
-    Float_t   Muon_dxy[N_KEEP_MU_E_];
-    Float_t   Muon_dz[N_KEEP_MU_E_];
-    Float_t   Muon_sip3d[N_KEEP_MU_E_];
-    Bool_t    Muon_isGlobal[N_KEEP_MU_E_];
-    Bool_t    Muon_isTracker[N_KEEP_MU_E_];
-    Bool_t    Muon_isPFcand[N_KEEP_MU_E_];
-    Int_t     Muon_tightCharge[N_KEEP_MU_E_];
-    Float_t   Muon_jetPtRelv2[N_KEEP_MU_E_];
-    Float_t   Muon_jetRelIso[N_KEEP_MU_E_];
+    UInt_t nElectron;
+    Float_t Electron_pt[N_KEEP_MU_E_];
+    Float_t Electron_eta[N_KEEP_MU_E_];
+    Float_t Electron_phi[N_KEEP_MU_E_];
+    Float_t Electron_mass[N_KEEP_MU_E_];
+    Int_t Electron_cutBased[N_KEEP_MU_E_];
+    Int_t Electron_charge[N_KEEP_MU_E_];
+    Float_t Electron_MVA[N_KEEP_MU_E_];
+    Float_t Electron_miniPFRelIso_all[N_KEEP_MU_E_];
+    Float_t Electron_dxy[N_KEEP_MU_E_];
+    Float_t Electron_dz[N_KEEP_MU_E_];
+    Float_t Electron_sip3d[N_KEEP_MU_E_];
+    Bool_t Electron_convVeto[N_KEEP_MU_E_];
+    UChar_t Electron_lostHits[N_KEEP_MU_E_];
+    Int_t Electron_tightCharge[N_KEEP_MU_E_];
+    Float_t Electron_sieie[N_KEEP_MU_E_];
+    Float_t Electron_hoe[N_KEEP_MU_E_];
+    Float_t Electron_deltaEtaSC[N_KEEP_MU_E_];
+    Float_t Electron_eInvMinusPInv[N_KEEP_MU_E_];
+    Float_t Electron_dr03EcalRecHitSumEt[N_KEEP_MU_E_];
+    Float_t Electron_dr03HcalDepth1TowerSumEt[N_KEEP_MU_E_];
+    Float_t Electron_dr03TkSumPt[N_KEEP_MU_E_];
+    Int_t Electron_vidBitmap[N_KEEP_MU_E_];
+    Float_t Electron_jetRelIso[N_KEEP_MU_E_];
+    Float_t Electron_eCorr[N_KEEP_MU_E_];
 
-  
-    Int_t     numPU;
-    Float_t   Pileup_nTrueInt;
+    UInt_t nMuon;
+    Float_t Muon_pt[N_KEEP_MU_E_];
+    Float_t Muon_eta[N_KEEP_MU_E_];
+    Float_t Muon_phi[N_KEEP_MU_E_];
+    Float_t Muon_mass[N_KEEP_MU_E_];
+    Int_t Muon_charge[N_KEEP_MU_E_];
+    Bool_t Muon_tightId[N_KEEP_MU_E_];
+    Bool_t Muon_mediumId[N_KEEP_MU_E_];
+    UChar_t Muon_tkIsoId[N_KEEP_MU_E_];
+    Float_t Muon_pfRelIso04_all[N_KEEP_MU_E_];
+    Float_t Muon_miniPFRelIso_all[N_KEEP_MU_E_];
+    Float_t Muon_dxy[N_KEEP_MU_E_];
+    Float_t Muon_dz[N_KEEP_MU_E_];
+    Float_t Muon_sip3d[N_KEEP_MU_E_];
+    Bool_t Muon_isGlobal[N_KEEP_MU_E_];
+    Bool_t Muon_isTracker[N_KEEP_MU_E_];
+    Bool_t Muon_isPFcand[N_KEEP_MU_E_];
+    Int_t Muon_tightCharge[N_KEEP_MU_E_];
+    Float_t Muon_jetPtRelv2[N_KEEP_MU_E_];
+    Float_t Muon_jetRelIso[N_KEEP_MU_E_];
 
-    UInt_t    nJet;
-    Float_t   Jet_btagCSVV2[N_KEEP_JET_];
-    Float_t   Jet_btagDeepB[N_KEEP_JET_];
-    Float_t   Jet_eta[N_KEEP_JET_];
-    Float_t   Jet_phi[N_KEEP_JET_];
-    Float_t   Jet_pt[N_KEEP_JET_];
-    Float_t   Jet_mass[N_KEEP_JET_];
-    Float_t   Jet_neHEF[N_KEEP_JET_];
-    Float_t   Jet_neEmEF[N_KEEP_JET_];
-    Int_t     Jet_nConstituents[N_KEEP_JET_];
-    Float_t   Jet_chHEF[N_KEEP_JET_];  
-    Float_t   Jet_chEmEF[N_KEEP_JET_];
-    Int_t     Jet_jetId[N_KEEP_JET_];
-    Int_t     Jet_hadronFlavour[N_KEEP_JET_];
-    Float_t   Jet_rawFactor[N_KEEP_JET_];
-    Float_t   Jet_L1[N_KEEP_JET_];
-    Float_t   Jet_L2L3[N_KEEP_JET_];
-    
+    Int_t numPU;
+    Float_t Pileup_nTrueInt;
+
+    UInt_t nJet;
+    Float_t Jet_btagCSVV2[N_KEEP_JET_];
+    Float_t Jet_btagDeepB[N_KEEP_JET_];
+    Float_t Jet_eta[N_KEEP_JET_];
+    Float_t Jet_phi[N_KEEP_JET_];
+    Float_t Jet_pt[N_KEEP_JET_];
+    Float_t Jet_mass[N_KEEP_JET_];
+    Float_t Jet_neHEF[N_KEEP_JET_];
+    Float_t Jet_neEmEF[N_KEEP_JET_];
+    Int_t Jet_nConstituents[N_KEEP_JET_];
+    Float_t Jet_chHEF[N_KEEP_JET_];
+    Float_t Jet_chEmEF[N_KEEP_JET_];
+    Int_t Jet_jetId[N_KEEP_JET_];
+    Int_t Jet_hadronFlavour[N_KEEP_JET_];
+    Float_t Jet_rawFactor[N_KEEP_JET_];
+    Float_t Jet_L1[N_KEEP_JET_];
+    Float_t Jet_L2L3[N_KEEP_JET_];
+
     Int_t GenPart_pdgId[N_KEEP_GEN_];
     Int_t GenPart_genPartIdxMother[N_KEEP_GEN_];
     Int_t GenPart_status[N_KEEP_GEN_];
@@ -136,9 +141,8 @@ public :
     Bool_t Flag_EcalDeadCellTriggerPrimitiveFilter;
     Bool_t Flag_BadPFMuonFilter;
     Bool_t Flag_ecalBadCalibFilter;
-    
-    
-    ClassDefOverride(ThreeLepSelector,0);
+
+    ClassDefOverride(ThreeLepSelector, 0);
 
     /*******************************************************/
     /* __ __  ___  ____  __  ___  ____  __     ____  __    */
@@ -146,7 +150,7 @@ public :
     /* \\ // ||=|| ||_// || ||=|| ||=)  ||    ||==   \\    */
     /*  \V/  || || || \\ || || || ||_)) ||__| ||___ \_))   */
     /*******************************************************/
-  
+
     Float_t weight;
     BranchManager b;
     std::vector<GoodPart> goodLeptons;
@@ -156,7 +160,7 @@ public :
     int nJets, nBJets;
     bool passZVeto;
     BTagCalibration calib;
-    BTagCalibrationReader btag_reader; // central sys type
+    BTagCalibrationReader btag_reader;  // central sys type
     TH2D* Beff_b;
     TH2D* Beff_j;
     ULong64_t event;
@@ -166,7 +170,6 @@ public :
     TH2D* h_btag_eff_c;
     TH2D* h_btag_eff_udsg;
 
-    
     std::map<int, bool> eventVec;
     std::map<int, std::string> info;
 
@@ -179,7 +182,7 @@ public :
     Float_t PV_x;
     Float_t PV_y;
     Float_t PV_z;
-  
+
     /************************************************************/
     /* _____ __ __ __  __   ___ ______ __   ___   __  __  __    */
     /* ||    || || ||\ ||  //   | || | ||  // \\  ||\ || (( \   */
@@ -192,7 +195,7 @@ public :
     void setupJets();
     void setupChannel();
     void printInfo();
-  
+
     bool isGoodMuon(size_t);
     bool isLooseMuon(size_t);
     bool isGoodJet(size_t);
@@ -200,14 +203,13 @@ public :
     bool isGoodElectron(size_t);
     bool isLooseElectron(size_t);
 
-    bool passMVACut(std::vector<std::vector<double> >, int);
-    double mvaInterpolate(double pt, std::vector<double> );
-    std::map<int, std::vector<std::vector<double> > >  mvaValues;
+    bool passMVACut(std::vector<std::vector<double>>, int);
+    double mvaInterpolate(double pt, std::vector<double>);
+    std::map<int, std::vector<std::vector<double>>> mvaValues;
 
-    
     bool isLooseMVAElectron(size_t);
 
-    size_t getCloseJetIndex(LorentzVector&, double minDR=10);
+    size_t getCloseJetIndex(LorentzVector&, double minDR = 10);
     bool doesNotOverlap(size_t);
     bool passFullIso(LorentzVector&, double, double);
     bool doesPassZVeto(GoodPart&, std::vector<GoodPart>&);
@@ -218,25 +220,29 @@ public :
     bool MetFilter();
     float getBtagEffFromFile(double, double, int);
     double getWDecayScaleFactor();
-    
+
     //// General Functions
     int getSRBin() const;
     void clearValues();
     void ApplyScaleFactors();
 
     // Overloaded or necesary functions
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    virtual void    SetBranchesNanoAOD() override;
-    virtual void    SetupNewDirectory() override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
+    virtual void SetBranchesNanoAOD() override;
+    virtual void SetupNewDirectory() override;
     // Readers to access the data (delete the ones you do not need).
-    virtual void    SetScaleFactors() override;
-    virtual void    Init(TTree *tree) override;
+    virtual void SetScaleFactors() override;
+    virtual void Init(TTree* tree) override;
 
-    ///ignore
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override {return;}
-    virtual void    SetBranchesUWVV() override {return;}
+    /// ignore
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override {
+        return;
+    }
+    virtual void SetBranchesUWVV() override { return; }
 };
 
 #endif
-

--- a/interface/WGenSelector.h
+++ b/interface/WGenSelector.h
@@ -1,23 +1,23 @@
 #ifndef WGenSelector_h
 #define WGenSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/NanoGenSelectorBase.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 class WGenSelector : public NanoGenSelectorBase {
-public :
+   public:
     // Derived values
     LorentzVector nu;
     LorentzVector wCand;
@@ -25,24 +25,24 @@ public :
     float mTtrue;
     float mTmet;
     float cenWeight;
-    
+
     float ptl_smear;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    WGenSelector(TTree * /*tree*/ =0) { }
-    ~WGenSelector() { }
+    virtual void Init(TTree* tree) override;
+    WGenSelector(TTree* /*tree*/ = 0) {}
+    ~WGenSelector() {}
 
-    ClassDefOverride(WGenSelector,0);
+    ClassDefOverride(WGenSelector, 0);
 
-protected:
+   protected:
     virtual void SetComposite() override;
-    virtual void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void FillHistogramsByName(Long64_t entry, std::string& toAppend, std::pair<Systematic, std::string> variation);
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void FillHistograms(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistogramsByName(Long64_t entry, std::string& toAppend,
+                              std::pair<Systematic, std::string> variation);
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
 };
 
 #endif
-
-
-

--- a/interface/WZBackgroundSelector.h
+++ b/interface/WZBackgroundSelector.h
@@ -6,10 +6,10 @@
 #include "Analysis/VVAnalysis/interface/WZSelector.h"
 
 class WZBackgroundSelector : public WZSelector {
-public :
-    ScaleFactor * fakeRate_allE_;
-    ScaleFactor * fakeRate_allMu_;
-    
+   public:
+    ScaleFactor* fakeRate_allE_;
+    ScaleFactor* fakeRate_allMu_;
+
     TH1D* mjjHistPPF_;
     TH1D* mjjHistPFP_;
     TH1D* mjjHistFPP_;
@@ -24,12 +24,13 @@ public :
     TH1D* ZMassHistFPF_;
     TH1D* ZMassHistPFF_;
     TH1D* ZMassHistFFF_;
-    
-    virtual void    SetupNewDirectory() override;
-    virtual void    SlaveBegin(TTree *tree) override;
 
-    ClassDefOverride(WZBackgroundSelector,0);
-private:
+    virtual void SetupNewDirectory() override;
+    virtual void SlaveBegin(TTree* tree) override;
+
+    ClassDefOverride(WZBackgroundSelector, 0);
+
+   private:
     float getl1FakeRate();
     float getl2FakeRate();
     float getl3FakeRate();
@@ -41,7 +42,8 @@ private:
     bool IsPFFRegion();
     bool IsFFFRegion();
     float getEventWeight();
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
 };
 
 #endif

--- a/interface/WZSelector.h
+++ b/interface/WZSelector.h
@@ -1,12 +1,12 @@
 #ifndef WZSelector_h
 #define WZSelector_h
 
+#include <TH3.h>
 #include <vector>
 #include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
-#include <TH3.h>
 
 class WZSelector : public WZSelectorBase {
-public :
+   public:
     bool doSystematics_ = false;
     bool applyFullSelection_ = true;
     bool isaQGC_ = false;
@@ -73,7 +73,7 @@ public :
     Float_t l1PtScaleCorrErr;
     Float_t l2PtScaleCorrErr;
     Float_t l3PtScaleCorrErr;
-    
+
     TBranch* b_l3MtToMET;
     TBranch* b_MtToMET;
     TBranch* b_pdfWeights;
@@ -119,17 +119,21 @@ public :
     TBranch* b_type1_pfMETEt_unclusteredEnDown;
 
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    virtual void    SetupNewDirectory() override;
+    virtual void Init(TTree* tree) override;
+    virtual void SetupNewDirectory() override;
 
-    ClassDefOverride(WZSelector,0);
-protected:
-    virtual void    SetBranchesUWVV() override;
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void FillVBSHistograms(float weight, bool noBlind, 
-            std::pair<Systematic, std::string> variation);
-    bool PassesBaseSelection(Long64_t entry, bool tightLeps, Selection selection);
+    ClassDefOverride(WZSelector, 0);
+
+   protected:
+    virtual void SetBranchesUWVV() override;
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
+    void FillVBSHistograms(float weight, bool noBlind,
+                           std::pair<Systematic, std::string> variation);
+    bool PassesBaseSelection(Long64_t entry, bool tightLeps,
+                             Selection selection);
     bool PassesVBSSelection(bool noBlind);
     bool PassesVBSBackgroundControlSelection();
     bool PassesFullWZSelection(Long64_t entry);
@@ -139,4 +143,3 @@ protected:
 };
 
 #endif
-

--- a/interface/WZSelectorBase.h
+++ b/interface/WZSelectorBase.h
@@ -1,28 +1,28 @@
 #ifndef WZSelectorBase_h
 #define WZSelectorBase_h
 
-#include <TROOT.h>
 #include <TChain.h>
+#include <TEfficiency.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
-#include <TEfficiency.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
+#include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/helpers.h"
-#include "Analysis/VVAnalysis/interface/BranchManager.h"
 
 class WZSelectorBase : public SelectorBase {
-public :
+   public:
     ScaleFactor* pileupSF_;
     ScaleFactor* muonSF_;
-    ScaleFactor* eIdSF_ ;
+    ScaleFactor* eIdSF_;
     ScaleFactor* eGsfSF_;
     ScaleFactor* mIdSF_;
     ScaleFactor* mIsoSF_;
@@ -52,7 +52,7 @@ public :
     Float_t l2Mass;
     Float_t l3Mass;
 
-    //NanoAOD variables
+    // NanoAOD variables
     static const unsigned int N_KEEP_MU_E_ = 20;
     UInt_t nElectron;
     UInt_t nMuon;
@@ -118,18 +118,18 @@ public :
     Bool_t Flag_goodVerticesPass;
     Bool_t Flag_eeBadScFilterPass;
     Bool_t Flag_globalTightHalo2016FilterPass;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    SetScaleFactors() override;
-    virtual void    Init(TTree *tree) override;
+    virtual void SetScaleFactors() override;
+    virtual void Init(TTree* tree) override;
 
-    ClassDefOverride(WZSelectorBase,0);
+    ClassDefOverride(WZSelectorBase, 0);
 
-protected:
+   protected:
     std::vector<std::string> nonprompt3l_ = {
-        "tt-lep", "st-schan", "st-tchan-t", "st-tchan-tbar",
-        "st-tw", "st-tbarw", "DYm50", "DYm50-1j",
-        "DYm50-2j","DYm50-3j","DYm50-4j", "DYm50__LO",
+        "tt-lep",   "st-schan", "st-tchan-t", "st-tchan-tbar",
+        "st-tw",    "st-tbarw", "DYm50",      "DYm50-1j",
+        "DYm50-2j", "DYm50-3j", "DYm50-4j",   "DYm50__LO",
     };
 
     bool isNonpromptEstimate_;
@@ -143,10 +143,12 @@ protected:
     bool tightZLeptons();
     bool IsGenMatched3l();
     virtual std::string GetNameFromFile() override;
-    virtual void    SetBranchesNanoAOD() override;
-    virtual void    SetBranchesUWVV() override;
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void SetBranchesNanoAOD() override;
+    virtual void SetBranchesUWVV() override;
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     void ApplyScaleFactors();
     void SetLeptonVarsNano();
     void SetMasses();
@@ -155,4 +157,3 @@ protected:
 };
 
 #endif
-

--- a/interface/ZGenSelector.h
+++ b/interface/ZGenSelector.h
@@ -1,44 +1,42 @@
 #ifndef ZGenSelector_h
 #define ZGenSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/NanoGenSelectorBase.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 class ZGenSelector : public NanoGenSelectorBase {
-public :
+   public:
     // Derived values
     LorentzVector zCand;
     TTreeReaderValue<Int_t> Generator_id1 = {fReader, "Generator_id1"};
     TTreeReaderValue<Int_t> Generator_id2 = {fReader, "Generator_id2"};
     float cenWeight;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    Init(TTree *tree) override;
-    ZGenSelector(TTree * /*tree*/ =0) { }
-    ~ZGenSelector() { }
+    virtual void Init(TTree *tree) override;
+    ZGenSelector(TTree * /*tree*/ = 0) {}
+    ~ZGenSelector() {}
 
-    ClassDefOverride(ZGenSelector,0);
+    ClassDefOverride(ZGenSelector, 0);
 
-protected:
+   protected:
     virtual void SetComposite() override;
-    virtual void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void FillHistograms(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
 };
 
 #endif
-
-
-
-

--- a/interface/ZSelector.h
+++ b/interface/ZSelector.h
@@ -1,28 +1,28 @@
 #ifndef ZSelector_h
 #define ZSelector_h
 
-#include <TROOT.h>
 #include <TChain.h>
 #include <TFile.h>
-#include <TSelector.h>
 #include <TH1.h>
 #include <TH2.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <exception>
 #include <iostream>
 
 // Headers needed by this particular selector
 #include <vector>
+#include "Analysis/VVAnalysis/interface/BranchManager.h"
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include "Analysis/VVAnalysis/interface/BranchManager.h"
 
 #include "Analysis/VVAnalysis/interface/helpers.h"
 
 class ZSelector : public SelectorBase {
-public :
+   public:
     ScaleFactor* pileupSF_ = nullptr;
     ScaleFactor* muonSF_ = nullptr;
-    ScaleFactor* eIdSF_  = nullptr;
+    ScaleFactor* eIdSF_ = nullptr;
     ScaleFactor* eGsfSF_ = nullptr;
     ScaleFactor* mIdSF_ = nullptr;
     ScaleFactor* mIsoSF_ = nullptr;
@@ -89,7 +89,7 @@ public :
     Bool_t SingleMuon_Trigger;
     Bool_t SingleElectron_Trigger;
     Int_t numPU;
-    
+
     // UWVV specific branches
     Float_t nTruePU;
 
@@ -110,29 +110,30 @@ public :
     TBranch* b_ZMass;
 
     BranchManager b;
-    
+
     // Readers to access the data (delete the ones you do not need).
-    virtual void    SetScaleFactors() override;
-    virtual void    Init(TTree *tree) override;
-    ZSelector(TTree * /*tree*/ =0) { }
-    ~ZSelector() { }
-    virtual void    SetupNewDirectory() override;
+    virtual void SetScaleFactors() override;
+    virtual void Init(TTree* tree) override;
+    ZSelector(TTree* /*tree*/ = 0) {}
+    ~ZSelector() {}
+    virtual void SetupNewDirectory() override;
 
-    ClassDefOverride(ZSelector,0);
+    ClassDefOverride(ZSelector, 0);
 
-protected:
+   protected:
     bool zlep1IsTight();
     bool zlep2IsTight();
     bool tightZLeptons();
-    virtual void    SetBranchesNanoAOD() override;
-    virtual void    SetBranchesUWVV() override;
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void SetBranchesNanoAOD() override;
+    virtual void SetBranchesUWVV() override;
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
     void ApplyScaleFactors();
     void SetComposite();
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
 };
 
 #endif
-
-

--- a/interface/ZZGenSelector.h
+++ b/interface/ZZGenSelector.h
@@ -1,14 +1,13 @@
 #ifndef ZZGenSelector_h
 #define ZZGenSelector_h
 
+#include <TH3.h>
 #include <vector>
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include <TH3.h>
 
 class ZZGenSelector : public SelectorBase {
-public :
-    
-    float GendPhiZZ; //DeltaPhi between Z1 and Z2
+   public:
+    float GendPhiZZ;  // DeltaPhi between Z1 and Z2
     Float_t GenMass;
     Float_t GenPt;
     Float_t GenEta;
@@ -19,7 +18,7 @@ public :
     Float_t GenZ2pt;
     Float_t GenZ1Phi;
     Float_t GenZ2Phi;
- 
+
     Float_t Genl1Pt;
     Float_t Genl2Pt;
     Float_t Genl3Pt;
@@ -32,7 +31,7 @@ public :
     Float_t Genl2Phi;
     Float_t Genl3Phi;
     Float_t Genl4Phi;
-    
+
     TBranch* b_GenZ1mass;
     TBranch* b_GenZ2mass;
     TBranch* b_GenZ1pt;
@@ -54,28 +53,31 @@ public :
     TBranch* b_Genl1Phi;
     TBranch* b_Genl2Phi;
     TBranch* b_Genl3Phi;
-    TBranch* b_Genl4Phi; 
+    TBranch* b_Genl4Phi;
 
     // Readers to access the data (delete the ones you do not need).
-    ZZGenSelector(TTree * /*tree*/ =0) { }
-    virtual ~ZZGenSelector() { }
-    virtual void    Init(TTree *tree) override;
-    virtual void    SetupNewDirectory() override;
+    ZZGenSelector(TTree* /*tree*/ = 0) {}
+    virtual ~ZZGenSelector() {}
+    virtual void Init(TTree* tree) override;
+    virtual void SetupNewDirectory() override;
 
-    ClassDefOverride(ZZGenSelector,0);
-protected:
-    void LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    void LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) override;
-    virtual void    SetBranchesNanoAOD() override;
-    virtual void    SetBranchesUWVV() override;
-    
-    void SetVariables(Long64_t entry); 
+    ClassDefOverride(ZZGenSelector, 0);
+
+   protected:
+    void LoadBranchesUWVV(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void LoadBranchesNanoAOD(
+        Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    virtual void SetBranchesNanoAOD() override;
+    virtual void SetBranchesUWVV() override;
+
+    void SetVariables(Long64_t entry);
     bool ZZSelection();
     bool Z4lSelection();
     bool ZSelection();
-    void FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) override;
+    void FillHistograms(Long64_t entry,
+                        std::pair<Systematic, std::string> variation) override;
     bool e1e2IsZ1();
 };
 
 #endif
-

--- a/interface/disambiguateFinalStates.h
+++ b/interface/disambiguateFinalStates.h
@@ -10,58 +10,69 @@
 #ifndef disambiguateFinalStates_h
 #define disambiguateFinalStates_h
 
-#include <TROOT.h>
 #include <TChain.h>
-#include <TFile.h>
-#include <TSelector.h>
 #include <TEntryList.h>
+#include <TFile.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <TTreeFormula.h>
 
 class disambiguateFinalStates : public TSelector {
-public :
-  TTree          *fChain;
+   public:
+    TTree *fChain;
 
-  Float_t         Mass;
-  ULong64_t        evt;
-  UInt_t           run;
+    Float_t Mass;
+    ULong64_t evt;
+    UInt_t run;
 
-  TBranch        *b_Mass;
-  TBranch        *b_evt;
-  TBranch        *b_run;
+    TBranch *b_Mass;
+    TBranch *b_evt;
+    TBranch *b_run;
 
-  TEntryList     *fBestCandidateEntryList;
+    TEntryList *fBestCandidateEntryList;
 
-  // TODO Add TTreeFormula, fix issue when using chain.Process 
-  // over multiple files (currently segfaults)
-  TTreeFormula   *fCutFormula;
+    // TODO Add TTreeFormula, fix issue when using chain.Process
+    // over multiple files (currently segfaults)
+    TTreeFormula *fCutFormula;
 
-  disambiguateFinalStates(TTree * /*tree*/ =0) : fChain(0), fBestCandidateEntryList(0), fCutFormula(0), fCurrentRun(-1), fCurrentEvt(-1) { }
-  virtual ~disambiguateFinalStates() { SafeDelete(fBestCandidateEntryList); SafeDelete(fCutFormula); }
-  virtual Int_t   Version() const { return 2; }
-  virtual void    Begin(TTree *tree);
-  virtual void    SlaveBegin(TTree *tree);
-  virtual void    Init(TTree *tree);
-  virtual Bool_t  Notify();
-  virtual Bool_t  Process(Long64_t entry);
-  virtual Int_t   GetEntry(Long64_t entry, Int_t getall = 0) { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
-  virtual void    SetOption(const char *option) { fOption = option; }
-  virtual void    SetObject(TObject *obj) { fObject = obj; }
-  virtual void    SetInputList(TList *input) { fInput = input; }
-  virtual TList  *GetOutputList() const { return fOutput; }
-  virtual void    SlaveTerminate();
-  virtual void    Terminate();
-  void setZCandidateBranchName(const char* name) { zCand_name = const_cast<char*>(name); }
+    disambiguateFinalStates(TTree * /*tree*/ = 0)
+        : fChain(0),
+          fBestCandidateEntryList(0),
+          fCutFormula(0),
+          fCurrentRun(-1),
+          fCurrentEvt(-1) {}
+    virtual ~disambiguateFinalStates() {
+        SafeDelete(fBestCandidateEntryList);
+        SafeDelete(fCutFormula);
+    }
+    virtual Int_t Version() const { return 2; }
+    virtual void Begin(TTree *tree);
+    virtual void SlaveBegin(TTree *tree);
+    virtual void Init(TTree *tree);
+    virtual Bool_t Notify();
+    virtual Bool_t Process(Long64_t entry);
+    virtual Int_t GetEntry(Long64_t entry, Int_t getall = 0) {
+        return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0;
+    }
+    virtual void SetOption(const char *option) { fOption = option; }
+    virtual void SetObject(TObject *obj) { fObject = obj; }
+    virtual void SetInputList(TList *input) { fInput = input; }
+    virtual TList *GetOutputList() const { return fOutput; }
+    virtual void SlaveTerminate();
+    virtual void Terminate();
+    void setZCandidateBranchName(const char *name) {
+        zCand_name = const_cast<char *>(name);
+    }
 
-  ClassDef(disambiguateFinalStates,0);
+    ClassDef(disambiguateFinalStates, 0);
 
-private :
-  void findBestEntry();
-  UInt_t fCurrentRun;
-  ULong64_t fCurrentEvt;
-  std::vector<Long64_t> fEntriesToCompare;
-  std::vector<Float_t> fEntryDiscriminants;
-  char* zCand_name;
+   private:
+    void findBestEntry();
+    UInt_t fCurrentRun;
+    ULong64_t fCurrentEvt;
+    std::vector<Long64_t> fEntriesToCompare;
+    std::vector<Float_t> fEntryDiscriminants;
+    char *zCand_name;
 };
 
 #endif
-

--- a/interface/disambiguateFinalStatesZZ.h
+++ b/interface/disambiguateFinalStatesZZ.h
@@ -2,9 +2,9 @@
  *
  * TSelector deduplicate events in combinatorical ntuple
  * by choosing event with l1_l2_Mass pairing closest to
- * M_PDG(Z) = 91.1876 
+ * M_PDG(Z) = 91.1876
  * with the highest scalar Pt sum of the remaining leptons
- * used as a tiebreaker. 
+ * used as a tiebreaker.
  *
  * Modified from K. Long, U. Wisconsin
  *
@@ -13,85 +13,98 @@
 #ifndef disambiguateFinalStatesZZ_h
 #define disambiguateFinalStatesZZ_h
 
-#include <TROOT.h>
 #include <TChain.h>
-#include <TFile.h>
-#include <TSelector.h>
 #include <TEntryList.h>
+#include <TFile.h>
+#include <TROOT.h>
+#include <TSelector.h>
 #include <TTreeFormula.h>
 
 class disambiguateFinalStatesZZ : public TSelector {
-public :
-  TTree          *fChain;
+   public:
+    TTree *fChain;
 
-  float           l1_l2_Mass;
-  float           l1_Pt;
-  float           l2_Pt;
-  float           l3_l4_Mass;
-  float           l3_Pt;
-  float           l4_Pt;
-  ULong64_t        evt;
-  UInt_t           run;
+    float l1_l2_Mass;
+    float l1_Pt;
+    float l2_Pt;
+    float l3_l4_Mass;
+    float l3_Pt;
+    float l4_Pt;
+    ULong64_t evt;
+    UInt_t run;
 
-  TBranch        *b_l1_l2_Mass;
-  TBranch        *b_l1_Pt; 
-  TBranch        *b_l2_Pt;
-  TBranch        *b_l3_l4_Mass;
-  TBranch        *b_l3_Pt;
-  TBranch        *b_l4_Pt;
+    TBranch *b_l1_l2_Mass;
+    TBranch *b_l1_Pt;
+    TBranch *b_l2_Pt;
+    TBranch *b_l3_l4_Mass;
+    TBranch *b_l3_Pt;
+    TBranch *b_l4_Pt;
 
-  TBranch        *b_evt;
-  TBranch        *b_run;
+    TBranch *b_evt;
+    TBranch *b_run;
 
-  TEntryList     *fBestCandidateEntryList;
-  
-  // TODO Add TTreeFormula, fix issue when using chain.Process 
-  // over multiple files (currently segfaults)
-  TTreeFormula   *fCutFormula;
+    TEntryList *fBestCandidateEntryList;
 
+    // TODO Add TTreeFormula, fix issue when using chain.Process
+    // over multiple files (currently segfaults)
+    TTreeFormula *fCutFormula;
 
-  //disambiguateFinalStatesZZ(TTree * /*tree*/ =0) : fChain(0), fBestCandidateEntryList(0), /*fCutFormula(0),*/ fCurrentRun(-1), fCurrentEvt(-1) { }
-  disambiguateFinalStatesZZ(TTree * /*tree*/ =0) : fChain(0), fBestCandidateEntryList(0), fCutFormula(0), fCurrentRun(-1), fCurrentEvt(-1) { }
-  //virtual ~disambiguateFinalStatesZZ() { SafeDelete(fBestCandidateEntryList); /*SafeDelete(fCutFormula)*/; }
-  virtual ~disambiguateFinalStatesZZ() { SafeDelete(fBestCandidateEntryList); SafeDelete(fCutFormula); }
-  virtual Int_t   Version() const { return 2; }
-  virtual void    Begin(TTree *tree);
-  virtual void    SlaveBegin(TTree *tree);
-  virtual void    Init(TTree *tree);
-  virtual Bool_t  Notify();
-  virtual Bool_t  Process(Long64_t entry);
-  virtual Int_t   GetEntry(Long64_t entry, Int_t getall = 0) { return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0; }
-  virtual void    SetOption(const char *option) { fOption = option; }
-  virtual void    SetObject(TObject *obj) { fObject = obj; }
-  virtual void    SetInputList(TList *input) { fInput = input; }
-  virtual TList  *GetOutputList() const { return fOutput; }
-  virtual void    SlaveTerminate();
-  virtual void    Terminate();
-  void setZCandidateBranchName(const char* name1,const char* name2, const char* name3,const char* name4,const char* name5,const char* name6) { 
-    l1_l2_Cand_mass = const_cast<char*>(name1);  
-    l1_Cand_pt = const_cast<char*>(name2);  
-    l2_Cand_pt = const_cast<char*>(name3); 
-    l3_l4_Cand_mass = const_cast<char*>(name4); 
-    l3_Cand_pt = const_cast<char*>(name5);
-    l4_Cand_pt = const_cast<char*>(name6); 
-  }
+    // disambiguateFinalStatesZZ(TTree * /*tree*/ =0) : fChain(0),
+    // fBestCandidateEntryList(0), /*fCutFormula(0),*/ fCurrentRun(-1),
+    // fCurrentEvt(-1) { }
+    disambiguateFinalStatesZZ(TTree * /*tree*/ = 0)
+        : fChain(0),
+          fBestCandidateEntryList(0),
+          fCutFormula(0),
+          fCurrentRun(-1),
+          fCurrentEvt(-1) {}
+    // virtual ~disambiguateFinalStatesZZ() {
+    // SafeDelete(fBestCandidateEntryList); /*SafeDelete(fCutFormula)*/; }
+    virtual ~disambiguateFinalStatesZZ() {
+        SafeDelete(fBestCandidateEntryList);
+        SafeDelete(fCutFormula);
+    }
+    virtual Int_t Version() const { return 2; }
+    virtual void Begin(TTree *tree);
+    virtual void SlaveBegin(TTree *tree);
+    virtual void Init(TTree *tree);
+    virtual Bool_t Notify();
+    virtual Bool_t Process(Long64_t entry);
+    virtual Int_t GetEntry(Long64_t entry, Int_t getall = 0) {
+        return fChain ? fChain->GetTree()->GetEntry(entry, getall) : 0;
+    }
+    virtual void SetOption(const char *option) { fOption = option; }
+    virtual void SetObject(TObject *obj) { fObject = obj; }
+    virtual void SetInputList(TList *input) { fInput = input; }
+    virtual TList *GetOutputList() const { return fOutput; }
+    virtual void SlaveTerminate();
+    virtual void Terminate();
+    void setZCandidateBranchName(const char *name1, const char *name2,
+                                 const char *name3, const char *name4,
+                                 const char *name5, const char *name6) {
+        l1_l2_Cand_mass = const_cast<char *>(name1);
+        l1_Cand_pt = const_cast<char *>(name2);
+        l2_Cand_pt = const_cast<char *>(name3);
+        l3_l4_Cand_mass = const_cast<char *>(name4);
+        l3_Cand_pt = const_cast<char *>(name5);
+        l4_Cand_pt = const_cast<char *>(name6);
+    }
 
-  ClassDef(disambiguateFinalStatesZZ,0);
+    ClassDef(disambiguateFinalStatesZZ, 0);
 
-private :
-  void findBestEntry();
-  UInt_t fCurrentRun;
-  ULong64_t fCurrentEvt;
-  std::vector<Long64_t> fEntriesToCompare;
-  std::vector<float> fEntryDiscriminants; 
-  std::vector<float> fEntryZ2PtSum;
-  char* l1_l2_Cand_mass; 
-  char* l1_Cand_pt;
-  char* l2_Cand_pt; 
-  char* l3_l4_Cand_mass; 
-  char* l3_Cand_pt;
-  char* l4_Cand_pt; 
+   private:
+    void findBestEntry();
+    UInt_t fCurrentRun;
+    ULong64_t fCurrentEvt;
+    std::vector<Long64_t> fEntriesToCompare;
+    std::vector<float> fEntryDiscriminants;
+    std::vector<float> fEntryZ2PtSum;
+    char *l1_l2_Cand_mass;
+    char *l1_Cand_pt;
+    char *l2_Cand_pt;
+    char *l3_l4_Cand_mass;
+    char *l3_Cand_pt;
+    char *l4_Cand_pt;
 };
 
 #endif
-

--- a/interface/helpers.h
+++ b/interface/helpers.h
@@ -1,31 +1,28 @@
 #ifndef helpers_h
 #define helpers_h
 
-#include "DataFormats/Candidate/interface/Particle.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/Particle.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 typedef reco::Particle::PolarLorentzVector LorentzVector;
 
 namespace helpers {
-  template<class T>
-  bool overlapsCollection(const LorentzVector& cand,
-			  T collection,
-			  const float deltaRCut,
-			  size_t maxCompare) {
-    for(size_t i = 0; i < std::min(maxCompare, collection.size()); ++i) {
-      if (reco::deltaR(collection[i], cand) < deltaRCut) {
-	return true;
-      }
+template <class T>
+bool overlapsCollection(const LorentzVector& cand, T collection,
+                        const float deltaRCut, size_t maxCompare) {
+    for (size_t i = 0; i < std::min(maxCompare, collection.size()); ++i) {
+        if (reco::deltaR(collection[i], cand) < deltaRCut) {
+            return true;
+        }
     }
     return false;
-  }
-
-  //bool compareByPt (const reco::Candidate& a, const reco::Candidate& b) {
-  //    return a.pt() > b.pt();
-  //}
 }
-    
-#endif
 
+// bool compareByPt (const reco::Candidate& a, const reco::Candidate& b) {
+//    return a.pt() > b.pt();
+//}
+}  // namespace helpers
+
+#endif

--- a/interface/printInfo.h
+++ b/interface/printInfo.h
@@ -1,149 +1,181 @@
 
 std::string boolStr(bool val) {
-    if(val) return "true";
-    else    return "false";
+    if (val)
+        return "true";
+    else
+        return "false";
 }
-
-
 
 void ThreeLepSelector::printInfo() {
     int num;
 
-
-    if(! eventVec[event]) return;
+    if (!eventVec[event]) return;
     printf("Event %d, lumi %d\n", (int)event, (int)lumi);
     std::cout << info[event] << std::endl;
-    printf(" #: %6s %5s  Id\n","pt", "eta");
+    printf(" #: %6s %5s  Id\n", "pt", "eta");
     printf("  : %6.4f %6.4f %6.4f\n", PV_x, PV_y, PV_z);
 
-    
-    num=0;
+    num = 0;
     printf("-------leps-----------\n");
     printf("Muon: pt eta id iso tightcharge dz d0 sip ptratio ptrel\n");
     // printf("Elec: pt eta id mva cutbased iso dz d0 sip ptratio ptrel\n");
     // printf("Elec: sieie hoe 1/e-1/pt ecalSumEt hcalSumEt tkSumPt\n");
-    for(auto lep : goodLeptons) {
-	num++;
-	LorentzVector closeJet(get4Vector(PID_JET, getCloseJetIndex(lep.v)));
-	printf("%2d: %6.2f %+3.2f %+d", num, lep.Pt(), lep.Eta(), -1*lep.Charge());
-	if(lep.Id() == PID_MUON) {
-	    printf(" %4.2f %d %+5.3f %+5.3f %5.3f, %5.3f %6.3f", Muon_miniPFRelIso_all[lep.index], Muon_tightCharge[lep.index], Muon_dz[lep.index], Muon_dxy[lep.index], Muon_sip3d[lep.index], (Muon_pt[lep.index]/closeJet.Pt()), LepRelPt(lep.v, closeJet));
-	}
-	else {  
-	}
-	printf("\n");
+    for (auto lep : goodLeptons) {
+        num++;
+        LorentzVector closeJet(get4Vector(PID_JET, getCloseJetIndex(lep.v)));
+        printf("%2d: %6.2f %+3.2f %+d", num, lep.Pt(), lep.Eta(),
+               -1 * lep.Charge());
+        if (lep.Id() == PID_MUON) {
+            printf(" %4.2f %d %+5.3f %+5.3f %5.3f, %5.3f %6.3f",
+                   Muon_miniPFRelIso_all[lep.index],
+                   Muon_tightCharge[lep.index], Muon_dz[lep.index],
+                   Muon_dxy[lep.index], Muon_sip3d[lep.index],
+                   (Muon_pt[lep.index] / closeJet.Pt()),
+                   LepRelPt(lep.v, closeJet));
+        } else {
+        }
+        printf("\n");
     }
-    num=0;
+    num = 0;
     printf("-----loose-muon-------\n");
-    for(auto lep : looseLeptons) {
-	if(lep.Id() != PID_MUON) continue;
-	int i = lep.index;
-	LorentzVector v = lep.v;
-	// for(int i = 0; i < (int)nMuon; i++) {
-    	num++;
-        //LorentzVector v = get4Vector(PID_MUON,i);
-	int closeIdx = getCloseJetIndex(v);
-	LorentzVector closeJet = get4Vector(PID_JET, closeIdx);
-	//closeJet += (1-Jet_L2L3[closeIdx])*v;
-        closeJet = (Jet_L1[closeIdx]*(1-Jet_rawFactor[closeIdx])*closeJet-v)*Jet_L2L3[closeIdx]+v;
-	
-    	//int i = lep.index;
-    	printf("%2d: %6.2f %+3.2f %+3.2f %+d", num, Muon_pt[i], Muon_eta[i], Muon_phi[i], -1*Muon_charge[i]);
-    	printf(" %+5.3f %+5.3f %5.3f | %4.2f %5.3f %6.3f rawpt %6.3f", Muon_dz[i], Muon_dxy[i], Muon_sip3d[i], Muon_miniPFRelIso_all[i], v.Pt()/closeJet.Pt(), LepRelPt(v, closeJet), Jet_rawFactor[getCloseJetIndex(v)]);
-    	printf("\n");
-    	printf("    %6.2f %+3.2f %+3.2f | %6.2f %+3.2f %+3.2f | %7.5f\n", v.Pt(), v.Eta(), v.Phi(), closeJet.Pt(), closeJet.Eta(), closeJet.Phi(), reco::deltaR(closeJet, v));
+    for (auto lep : looseLeptons) {
+        if (lep.Id() != PID_MUON) continue;
+        int i = lep.index;
+        LorentzVector v = lep.v;
+        // for(int i = 0; i < (int)nMuon; i++) {
+        num++;
+        // LorentzVector v = get4Vector(PID_MUON,i);
+        int closeIdx = getCloseJetIndex(v);
+        LorentzVector closeJet = get4Vector(PID_JET, closeIdx);
+        // closeJet += (1-Jet_L2L3[closeIdx])*v;
+        closeJet =
+            (Jet_L1[closeIdx] * (1 - Jet_rawFactor[closeIdx]) * closeJet - v) *
+                Jet_L2L3[closeIdx] +
+            v;
+
+        // int i = lep.index;
+        printf("%2d: %6.2f %+3.2f %+3.2f %+d", num, Muon_pt[i], Muon_eta[i],
+               Muon_phi[i], -1 * Muon_charge[i]);
+        printf(" %+5.3f %+5.3f %5.3f | %4.2f %5.3f %6.3f rawpt %6.3f",
+               Muon_dz[i], Muon_dxy[i], Muon_sip3d[i], Muon_miniPFRelIso_all[i],
+               v.Pt() / closeJet.Pt(), LepRelPt(v, closeJet),
+               Jet_rawFactor[getCloseJetIndex(v)]);
+        printf("\n");
+        printf("    %6.2f %+3.2f %+3.2f | %6.2f %+3.2f %+3.2f | %7.5f\n",
+               v.Pt(), v.Eta(), v.Phi(), closeJet.Pt(), closeJet.Eta(),
+               closeJet.Phi(), reco::deltaR(closeJet, v));
     }
     // printf("--------all-muon-------\n");
     // for(size_t index = 0; index < nMuon; index++) {
-    // 	printf("%2d: %6.2f %+3.2f %+d", (int)index, Muon_pt[index], Muon_eta[index], (int)(-1*Muon_charge[index]));
-    // 	printf(" %4.2f %d %+5.3f %+5.3f %5.3f %d", Muon_miniPFRelIso_all[index], Muon_tightCharge[index],
-    // 	       Muon_dz[index], Muon_dxy[index], Muon_sip3d[index], Muon_mediumId[index]);
-    // 	printf("\n");
+    // 	printf("%2d: %6.2f %+3.2f %+d", (int)index, Muon_pt[index],
+    // Muon_eta[index], (int)(-1*Muon_charge[index])); 	printf(" %4.2f %d %+5.3f
+    // %+5.3f %5.3f %d", Muon_miniPFRelIso_all[index], Muon_tightCharge[index],
+    // 	       Muon_dz[index], Muon_dxy[index], Muon_sip3d[index],
+    // Muon_mediumId[index]); 	printf("\n");
     // 	       }
 
-    num=0;
+    num = 0;
     printf("-----loose-elec-------\n");
-    for(auto lep : looseLeptons) {
-	if(lep.Id() != PID_ELECTRON) continue;
-	int i = lep.index;
-	LorentzVector v = lep.v;
-	//for(int i = 0; i < (int)nElectron; i++) {
-	num++;
-	int closeIdx = getCloseJetIndex(v);
-	LorentzVector closeJet = get4Vector(PID_JET, closeIdx);
-	//closeJet += (1-Jet_L2L3[closeIdx])*v;
-	closeJet = (Jet_L1[closeIdx]*(1-Jet_rawFactor[closeIdx])*closeJet-v)*Jet_L2L3[closeIdx]+v;
-	
-	//LorentzVector v = get4Vector(PID_ELECTRON, i);
-	//int i = lep.index;
-	printf("  : %6s %5s %5s %2s %4s %2s %5s %6s %6s %5s %5s %6s\n",
-	       "pt", "eta", "phi", "ch", "mva", "ID", "iso", "dz", "d0", "sip3d", "ratio", "ptrel");
-	printf("%2d: %6.2f %+3.2f %+3.2f %+d", num, Electron_pt[i]/CHGPT(i), Electron_eta[i], Electron_phi[i], -1*Electron_charge[i]);
-	printf(" %4.2f  %d %5.3f %+5.3f %+5.3f %5.3f %5.3f %6.3f %6.2f\n", Electron_MVA[i], Electron_cutBased[i], Electron_miniPFRelIso_all[i], Electron_dz[i], Electron_dxy[i], Electron_sip3d[i], v.Pt()/closeJet.Pt(), LepRelPt(v, closeJet), Electron_pt[i]/CHGPT(i)/Electron_eCorr[i]);
-	int DEtaInCut = READFROM(Electron_vidBitmap[i], 6, 3);
-	int DPhiInCut = READFROM(Electron_vidBitmap[i], 9, 3);
+    for (auto lep : looseLeptons) {
+        if (lep.Id() != PID_ELECTRON) continue;
+        int i = lep.index;
+        LorentzVector v = lep.v;
+        // for(int i = 0; i < (int)nElectron; i++) {
+        num++;
+        int closeIdx = getCloseJetIndex(v);
+        LorentzVector closeJet = get4Vector(PID_JET, closeIdx);
+        // closeJet += (1-Jet_L2L3[closeIdx])*v;
+        closeJet =
+            (Jet_L1[closeIdx] * (1 - Jet_rawFactor[closeIdx]) * closeJet - v) *
+                Jet_L2L3[closeIdx] +
+            v;
 
-	printf(" %6s %6s %7s %6s %6s %6s, %5s, %5s\n",   "sInIn", "HoverE", "1/E-1/p", "ECsum", "HCsum", "TKsum", "DnIn", "DphIn") ;
+        // LorentzVector v = get4Vector(PID_ELECTRON, i);
+        // int i = lep.index;
+        printf("  : %6s %5s %5s %2s %4s %2s %5s %6s %6s %5s %5s %6s\n", "pt",
+               "eta", "phi", "ch", "mva", "ID", "iso", "dz", "d0", "sip3d",
+               "ratio", "ptrel");
+        printf("%2d: %6.2f %+3.2f %+3.2f %+d", num, Electron_pt[i] / CHGPT(i),
+               Electron_eta[i], Electron_phi[i], -1 * Electron_charge[i]);
+        printf(" %4.2f  %d %5.3f %+5.3f %+5.3f %5.3f %5.3f %6.3f %6.2f\n",
+               Electron_MVA[i], Electron_cutBased[i],
+               Electron_miniPFRelIso_all[i], Electron_dz[i], Electron_dxy[i],
+               Electron_sip3d[i], v.Pt() / closeJet.Pt(), LepRelPt(v, closeJet),
+               Electron_pt[i] / CHGPT(i) / Electron_eCorr[i]);
+        int DEtaInCut = READFROM(Electron_vidBitmap[i], 6, 3);
+        int DPhiInCut = READFROM(Electron_vidBitmap[i], 9, 3);
 
-	printf(" %6.4f %6.4f %+6.4f %6.4f %6.4f %6.4f, %5d, %5d\n",  Electron_sieie[i],
-    	       Electron_hoe[i],
-    	       Electron_eInvMinusPInv[i],
-    	       Electron_dr03EcalRecHitSumEt[i],
-    	       Electron_dr03HcalDepth1TowerSumEt[i],
-    	       Electron_dr03TkSumPt[i],
-	       DEtaInCut, DPhiInCut
-	       
-    	       );
+        printf(" %6s %6s %7s %6s %6s %6s, %5s, %5s\n", "sInIn", "HoverE",
+               "1/E-1/p", "ECsum", "HCsum", "TKsum", "DnIn", "DphIn");
 
-	printf(" %6s %6s %7s %6s %6s %6s, %5s, %5s\n",
-    	       boolStr(Electron_sieie[i] < 0.031).c_str(),
-    	       boolStr(Electron_hoe[i] < 0.08).c_str(),
-    	       boolStr(abs(Electron_eInvMinusPInv[i]) < 0.01).c_str(),
-    	       boolStr(Electron_dr03EcalRecHitSumEt[i]/Electron_pt[i]*CHGPT(i) < 0.45).c_str(),
-    	       boolStr(Electron_dr03HcalDepth1TowerSumEt[i]/Electron_pt[i]*CHGPT(i) < 0.25).c_str(),
-    	       boolStr(Electron_dr03TkSumPt[i]/Electron_pt[i]*CHGPT(i) < 0.2).c_str(),
-	       boolStr(DEtaInCut >=1).c_str(),
-	       boolStr(DPhiInCut >=3).c_str()
-    	       );
-	printf(" %5s %5s %5s %5s %5s %5s %5s %5s %5s\n", "pt", "convV", "missV", "tChar", "dz", "d0", "sip3d", "mva", "iso");
-	printf(" %5s %5s %5s %5s %5s %5s %5s %5s %5s\n", boolStr(Electron_pt[i]/CHGPT(i) > 20).c_str(),
-	       boolStr(Electron_convVeto[i]).c_str(),
-	       boolStr(Electron_lostHits[i] == 0).c_str(),
-	       boolStr(Electron_tightCharge[i] == 2).c_str(),
-	       boolStr(abs(Electron_dz[i]) < 0.1).c_str(),
-	       boolStr(abs(Electron_dxy[i]) < 0.05).c_str(),
-	       boolStr(Electron_sip3d[i] < 4).c_str(),
-	       boolStr(passMVACut(mvaValues[4], i)).c_str(),
-	       boolStr(Electron_miniPFRelIso_all[i] < 0.12).c_str());
+        printf(" %6.4f %6.4f %+6.4f %6.4f %6.4f %6.4f, %5d, %5d\n",
+               Electron_sieie[i], Electron_hoe[i], Electron_eInvMinusPInv[i],
+               Electron_dr03EcalRecHitSumEt[i],
+               Electron_dr03HcalDepth1TowerSumEt[i], Electron_dr03TkSumPt[i],
+               DEtaInCut, DPhiInCut
 
-	printf("\n");
+        );
+
+        printf(
+            " %6s %6s %7s %6s %6s %6s, %5s, %5s\n",
+            boolStr(Electron_sieie[i] < 0.031).c_str(),
+            boolStr(Electron_hoe[i] < 0.08).c_str(),
+            boolStr(abs(Electron_eInvMinusPInv[i]) < 0.01).c_str(),
+            boolStr(Electron_dr03EcalRecHitSumEt[i] / Electron_pt[i] *
+                        CHGPT(i) <
+                    0.45)
+                .c_str(),
+            boolStr(Electron_dr03HcalDepth1TowerSumEt[i] / Electron_pt[i] *
+                        CHGPT(i) <
+                    0.25)
+                .c_str(),
+            boolStr(Electron_dr03TkSumPt[i] / Electron_pt[i] * CHGPT(i) < 0.2)
+                .c_str(),
+            boolStr(DEtaInCut >= 1).c_str(), boolStr(DPhiInCut >= 3).c_str());
+        printf(" %5s %5s %5s %5s %5s %5s %5s %5s %5s\n", "pt", "convV", "missV",
+               "tChar", "dz", "d0", "sip3d", "mva", "iso");
+        printf(" %5s %5s %5s %5s %5s %5s %5s %5s %5s\n",
+               boolStr(Electron_pt[i] / CHGPT(i) > 20).c_str(),
+               boolStr(Electron_convVeto[i]).c_str(),
+               boolStr(Electron_lostHits[i] == 0).c_str(),
+               boolStr(Electron_tightCharge[i] == 2).c_str(),
+               boolStr(abs(Electron_dz[i]) < 0.1).c_str(),
+               boolStr(abs(Electron_dxy[i]) < 0.05).c_str(),
+               boolStr(Electron_sip3d[i] < 4).c_str(),
+               boolStr(passMVACut(mvaValues[4], i)).c_str(),
+               boolStr(Electron_miniPFRelIso_all[i] < 0.12).c_str());
+
+        printf("\n");
     }
-    
-    
-    num=0;
+
+    num = 0;
     printf("-------Jets-----------\n");
-    for(auto lep : goodJets) {
-    	if(lep.passedJetSel()) {
-    	    num++;
-            printf("%2d: %6.2f %+4.2f %+4.2f %5.3f %5.3f\n", num, lep.Pt(), lep.Eta(), lep.Phi(), Jet_btagDeepB[lep.index], Jet_btagCSVV2[lep.index]);
-    	}
+    for (auto lep : goodJets) {
+        if (lep.passedJetSel()) {
+            num++;
+            printf("%2d: %6.2f %+4.2f %+4.2f %5.3f %5.3f\n", num, lep.Pt(),
+                   lep.Eta(), lep.Phi(), Jet_btagDeepB[lep.index],
+                   Jet_btagCSVV2[lep.index]);
+        }
     }
     // for(size_t i = 0; i < nJet; i++) {
     // 	if(Jet_btagDeepB[i] < 0.6) continue;
-    // 	printf("%2d: %6.2f %+4.2f %+4.2f %6.4f %6.4f %d\n", (int)i, Jet_pt[i], Jet_eta[i], Jet_phi[i], Jet_btagDeepB[i],  Jet_btagCSVV2[i], Jet_jetId[i]);
+    // 	printf("%2d: %6.2f %+4.2f %+4.2f %6.4f %6.4f %d\n", (int)i, Jet_pt[i],
+    // Jet_eta[i], Jet_phi[i], Jet_btagDeepB[i],  Jet_btagCSVV2[i],
+    // Jet_jetId[i]);
     // }
-    num=0;
+    num = 0;
     printf("-------BJets------------\n");
-    for(auto lep : goodJets) {
-	if(lep.passedBJetSel()) {
-	    num++;
-	    printf("%2d: %6.2f %+4.2f %+4.2f %5.3f %5.3f\n", num, lep.Pt(), lep.Eta(), lep.Phi(), Jet_btagDeepB[lep.index], Jet_btagCSVV2[lep.index]);
-	}
+    for (auto lep : goodJets) {
+        if (lep.passedBJetSel()) {
+            num++;
+            printf("%2d: %6.2f %+4.2f %+4.2f %5.3f %5.3f\n", num, lep.Pt(),
+                   lep.Eta(), lep.Phi(), Jet_btagDeepB[lep.index],
+                   Jet_btagCSVV2[lep.index]);
+        }
     }
     printf("-------MET------------\n");
     printf("  : %6.2f \n", MET);
 
     printf("----------------------\n\n");
-
 }
-

--- a/src/Efficiency.cc
+++ b/src/Efficiency.cc
@@ -1,27 +1,28 @@
 
 #include "Analysis/VVAnalysis/interface/Efficiency.h"
 #include "TLorentzVector.h"
-#define Fill1D(NAME, VALUE_) HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
+#define Fill1D(NAME, VALUE_) \
+    HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
 
-#define Fill2D(NAME, VALUE1_, VALUE2_) HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
+#define Fill2D(NAME, VALUE1_, VALUE2_) \
+    HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
 
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>LorentzVector;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
+void Efficiency::Init(TTree* tree) {
+    hists1D_ = {"GenElecPt",  "GenMuonPt",  "MatchElecPt", "MatchMuonPt",
+                "FakeElecPt", "FakeMuonPt", "NGenElec",    "NGenMuon",
+                "GenJetPt",   "GenBJetPt",  "MatchJetPt",  "MatchBJetPt",
+                "FakeJetPt",  "FakeBJetPt", "NGenBJet",    "NGenJet",
+                "NMatchBJet", "NFakeBJet"};
 
-
-void Efficiency::Init(TTree *tree) {
-
-    hists1D_ = {"GenElecPt", "GenMuonPt", "MatchElecPt", "MatchMuonPt",
-		"FakeElecPt", "FakeMuonPt", "NGenElec", "NGenMuon","GenJetPt", "GenBJetPt",
-		"MatchJetPt", "MatchBJetPt", "FakeJetPt", "FakeBJetPt", "NGenBJet", "NGenJet",
-		"NMatchBJet", "NFakeBJet"};
-    
     hists2D_ = {"BEff_b_btag", "BEff_j_btag", "GenbJetsvsJets"};
     allChannels_ = {{all, "all"}};
-    
-    b.SetTree(tree);    
+
+    b.SetTree(tree);
     SelectorBase::Init(tree);
-    
+
     TList* slaveClassList = (TList*)GetInputList()->Clone();
     slaveClassList->Add(new TNamed("isSlaveClass", "isSlaveClass"));
     TTTAna.SetInputList(slaveClassList);
@@ -37,13 +38,13 @@ void Efficiency::SetupNewDirectory() {
 
 void Efficiency::SetBranchesNanoAOD() {
     b.CleanUp();
-    
+
     b.SetBranch("nGenPart", nGenPart);
     b.SetBranch("GenPart_pt", GenPart_pt);
     b.SetBranch("GenPart_pdgId", GenPart_pdgId);
     b.SetBranch("GenPart_eta", GenPart_eta);
     b.SetBranch("GenPart_phi", GenPart_phi);
-    b.SetBranch("GenPart_mass",GenPart_mass);
+    b.SetBranch("GenPart_mass", GenPart_mass);
     b.SetBranch("GenPart_genPartIdxMother", GenPart_mother);
 
     b.SetBranch("nGenJet", nGenJet);
@@ -60,112 +61,121 @@ void Efficiency::clearValues() {
     Jets.clear();
 }
 
-void Efficiency::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void Efficiency::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     clearValues();
     b.SetEntry(entry);
 
-    TTTAna.LoadBranchesNanoAOD(entry,variation);
-    
+    TTTAna.LoadBranchesNanoAOD(entry, variation);
+
     if (nGenJet > N_KEEP_GEN_JET) {
-	std::string message = "Found more Gen jets than max read number. \n Found" ;
-	message += std::to_string(nGenJet);
-	message += " particles\n  --> Max read number was ";
-	message += std::to_string(N_KEEP_GEN_JET);
-	message += "\nExiting because this can cause problems. Increase N_KEEP_GEN_JET to avoid this error.\n";
-	throw std::domain_error(message);
+        std::string message =
+            "Found more Gen jets than max read number. \n Found";
+        message += std::to_string(nGenJet);
+        message += " particles\n  --> Max read number was ";
+        message += std::to_string(N_KEEP_GEN_JET);
+        message +=
+            "\nExiting because this can cause problems. Increase "
+            "N_KEEP_GEN_JET to avoid this error.\n";
+        throw std::domain_error(message);
     }
 
-    for (size_t i=0; i< nGenPart; i++) {
-	if (std::abs(GenPart_pdgId[i]) != PID_ELECTRON && std::abs(GenPart_pdgId[i]) != PID_MUON) continue;
-	if (GenPart_pt[i] < 20 || abs(GenPart_pdgId[GenPart_mother[i]]) != 24) continue;
+    for (size_t i = 0; i < nGenPart; i++) {
+        if (std::abs(GenPart_pdgId[i]) != PID_ELECTRON &&
+            std::abs(GenPart_pdgId[i]) != PID_MUON)
+            continue;
+        if (GenPart_pt[i] < 20 || abs(GenPart_pdgId[GenPart_mother[i]]) != 24)
+            continue;
 
-	Leptons.push_back(GenPart());
-	Leptons.back().SetupGen(GenPart_pt[i], GenPart_eta[i], GenPart_phi[i], GenPart_mass[i],
-				GenPart_pdgId[i]);
+        Leptons.push_back(GenPart());
+        Leptons.back().SetupGen(GenPart_pt[i], GenPart_eta[i], GenPart_phi[i],
+                                GenPart_mass[i], GenPart_pdgId[i]);
     }
 
-    for (size_t i=0; i < nGenJet; i++) {
-	if (GenJet_pt[i] < 25) continue;
-	
-	Jets.push_back(GenPart());
-	Jets.back().SetupGen(GenJet_pt[i], GenJet_eta[i], GenJet_phi[i], GenJet_mass[i],
-			     GenJet_partonFlavour[i]);
+    for (size_t i = 0; i < nGenJet; i++) {
+        if (GenJet_pt[i] < 25) continue;
+
+        Jets.push_back(GenPart());
+        Jets.back().SetupGen(GenJet_pt[i], GenJet_eta[i], GenJet_phi[i],
+                             GenJet_mass[i], GenJet_partonFlavour[i]);
     }
 
     fillReco(Leptons, TTTAna.goodLeptons);
     fillReco(Jets, TTTAna.goodJets);
 
-    
     weight = TTTAna.weight;
-    
+
     channelName_ = "all";
     channel_ = channelMap_[channelName_];
 }
 
-void Efficiency::fillReco(std::vector<GenPart>& genList, const std::vector<GoodPart>& recoList) {
-    for(auto reco : recoList) {
-	bool isMatched = false;
-	for(auto& gen : genList) {
-	    if (reco::deltaR(gen.gVector(), reco.v)<0.05) {
-		gen.SetupReco(reco);
-		isMatched = true;
-		break;
-	    }
-	}
-	if(!isMatched) {
-	    genList.push_back(GenPart());
-	    genList.back().SetupReco(reco);
-	}
+void Efficiency::fillReco(std::vector<GenPart>& genList,
+                          const std::vector<GoodPart>& recoList) {
+    for (auto reco : recoList) {
+        bool isMatched = false;
+        for (auto& gen : genList) {
+            if (reco::deltaR(gen.gVector(), reco.v) < 0.05) {
+                gen.SetupReco(reco);
+                isMatched = true;
+                break;
+            }
+        }
+        if (!isMatched) {
+            genList.push_back(GenPart());
+            genList.back().SetupReco(reco);
+        }
     }
 }
 
-void Efficiency::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void Efficiency::FillHistograms(Long64_t entry,
+                                std::pair<Systematic, std::string> variation) {
     int nGenElec = 0;
     int nGenMuon = 0;
     int nGenBJet = 0;
     int nGenJet = 0;
-    int nMatchBJet =0;
+    int nMatchBJet = 0;
     int nFakeBJet = 0;
 
-    for (auto part: Leptons) {
-	std::string partName = lepNameMap[part.Id()];
-	std::string partPt = partName + "Pt";
+    for (auto part : Leptons) {
+        std::string partName = lepNameMap[part.Id()];
+        std::string partPt = partName + "Pt";
 
-	if(part.isMatched()) {
-	    Fill1D("Match" + partPt, part.gPt());
-	} else if(part.isFaked()) {
-	    Fill1D("Fake" + partPt, part.rPt());
-	    continue;
-	}
-	Fill1D("Gen" + partPt, part.gPt());
+        if (part.isMatched()) {
+            Fill1D("Match" + partPt, part.gPt());
+        } else if (part.isFaked()) {
+            Fill1D("Fake" + partPt, part.rPt());
+            continue;
+        }
+        Fill1D("Gen" + partPt, part.gPt());
 
-	if (part.Id() == PID_MUON)  nGenMuon++;
-	else 	                    nGenElec++;        
+        if (part.Id() == PID_MUON)
+            nGenMuon++;
+        else
+            nGenElec++;
     }
 
-    for(auto jet: Jets) {
-	// Jets
-	if(jet.isMatched()) {
-	    Fill1D("MatchJetPt", jet.gPt());
-	} else if(jet.isFaked()) {
-	    Fill1D("FakeJetPt", jet.rPt());
-	}
-	if(!jet.isFaked()) {
-	    Fill1D("GenJetPt", jet.gPt());
+    for (auto jet : Jets) {
+        // Jets
+        if (jet.isMatched()) {
+            Fill1D("MatchJetPt", jet.gPt());
+        } else if (jet.isFaked()) {
+            Fill1D("FakeJetPt", jet.rPt());
+        }
+        if (!jet.isFaked()) {
+            Fill1D("GenJetPt", jet.gPt());
             nGenJet++;
-	}
+        }
 
-	// BJet
-        if(jet.isBMatched()) {
-	    Fill1D("MatchBJetPt", jet.gPt());
-	} else if(jet.isBFaked()) {
-	    Fill1D("FakeBJetPt", jet.rPt());
-	}
-        if(jet.isGenB()) {
-	    Fill1D("GenBJetPt", jet.gPt());
-	    nGenBJet++;
-	}
-        
+        // BJet
+        if (jet.isBMatched()) {
+            Fill1D("MatchBJetPt", jet.gPt());
+        } else if (jet.isBFaked()) {
+            Fill1D("FakeBJetPt", jet.rPt());
+        }
+        if (jet.isGenB()) {
+            Fill1D("GenBJetPt", jet.gPt());
+            nGenBJet++;
+        }
     }
 
     Fill2D("GenbJetsvsJets", nGenJet, nGenBJet);
@@ -177,6 +187,3 @@ void Efficiency::FillHistograms(Long64_t entry, std::pair<Systematic, std::strin
     Fill1D("NFakeBJet", nFakeBJet);
     return;
 }
-
-
-

--- a/src/FakeRateSelector.cc
+++ b/src/FakeRateSelector.cc
@@ -1,22 +1,16 @@
 #include "Analysis/VVAnalysis/interface/FakeRateSelector.h"
 #include <TStyle.h>
 
-void FakeRateSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
-    if (!passesLeptonVeto)
-        return;
-    if (l1Pt < 25 || l2Pt < 15)
-        return;
-    if (ZMass > 101.1876 || ZMass < 81.1876)
-        return;
-    if (type1_pfMETEt > 25)
-        return;
-    if (l3MtToMET > 30)
-        return;
-    if (!tightZLeptons())
-        return;
+void FakeRateSelector::FillHistograms(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
+    if (!passesLeptonVeto) return;
+    if (l1Pt < 25 || l2Pt < 15) return;
+    if (ZMass > 101.1876 || ZMass < 81.1876) return;
+    if (type1_pfMETEt > 25) return;
+    if (l3MtToMET > 30) return;
+    if (!tightZLeptons()) return;
 
-    if (!IsGenMatched3l())
-        return;
+    if (!IsGenMatched3l()) return;
 
     float pt_fillval = l3Pt;
     float eta_fillval = std::abs(l3Eta);
@@ -24,8 +18,7 @@ void FakeRateSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std:
     float loose_weight = weight;
     if (channel_ == eee || channel_ == emm) {
         loose_weight /= eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-    }
-    else if (channel_ == eem || channel_ == mmm) {
+    } else if (channel_ == eem || channel_ == mmm) {
         loose_weight /= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
     }
     passingLoose2D_->Fill(pt_fillval, eta_fillval, loose_weight);
@@ -42,12 +35,22 @@ void FakeRateSelector::SetupNewDirectory() {
     WZSelectorBase::SetupNewDirectory();
 
     const int nvarbins = 3;
-    double variable_pt_bins[nvarbins+1] = {10, 20, 30, FR_MAX_PT_};
-    AddObject<TH2D>(passingTight2D_, ("passingTight2D_"+channelName_).c_str(), "#eta; p_{T} [GeV]", nvarbins, variable_pt_bins, 3, 0, 2.5);
-    AddObject<TH1D>(passingTight1DPt_, ("passingTight1DPt_"+channelName_).c_str(), "Tight leptons; p_{T} [GeV]", nvarbins, variable_pt_bins);
-    AddObject<TH1D>(passingTight1DEta_, ("passingTight1DEta_"+channelName_).c_str(), "Tight leptons; #eta", 3, 0, 2.5);
-    
-    AddObject<TH2D>(passingLoose2D_, ("passingLoose2D_"+channelName_).c_str(), "#eta; p_{T} [GeV]", nvarbins, variable_pt_bins, 3, 0, 2.5);
-    AddObject<TH1D>(passingLoose1DPt_, ("passingLoose1DPt_"+channelName_).c_str(), "Loose leptons; p_{T} [GeV]", nvarbins, variable_pt_bins);
-    AddObject<TH1D>(passingLoose1DEta_, ("passingLoose1DEta_"+channelName_).c_str(), "Loose leptons; #eta", 3, 0, 2.5);
+    double variable_pt_bins[nvarbins + 1] = {10, 20, 30, FR_MAX_PT_};
+    AddObject<TH2D>(passingTight2D_, ("passingTight2D_" + channelName_).c_str(),
+                    "#eta; p_{T} [GeV]", nvarbins, variable_pt_bins, 3, 0, 2.5);
+    AddObject<TH1D>(passingTight1DPt_,
+                    ("passingTight1DPt_" + channelName_).c_str(),
+                    "Tight leptons; p_{T} [GeV]", nvarbins, variable_pt_bins);
+    AddObject<TH1D>(passingTight1DEta_,
+                    ("passingTight1DEta_" + channelName_).c_str(),
+                    "Tight leptons; #eta", 3, 0, 2.5);
+
+    AddObject<TH2D>(passingLoose2D_, ("passingLoose2D_" + channelName_).c_str(),
+                    "#eta; p_{T} [GeV]", nvarbins, variable_pt_bins, 3, 0, 2.5);
+    AddObject<TH1D>(passingLoose1DPt_,
+                    ("passingLoose1DPt_" + channelName_).c_str(),
+                    "Loose leptons; p_{T} [GeV]", nvarbins, variable_pt_bins);
+    AddObject<TH1D>(passingLoose1DEta_,
+                    ("passingLoose1DEta_" + channelName_).c_str(),
+                    "Loose leptons; #eta", 3, 0, 2.5);
 }

--- a/src/LowPileupSelector.cc
+++ b/src/LowPileupSelector.cc
@@ -2,13 +2,13 @@
 #include <TStyle.h>
 #include <regex>
 
-void LowPileupSelector::Init(TTree *tree)
-{
+void LowPileupSelector::Init(TTree *tree) {
     b.SetTree(tree);
-    if (name_.find("we") != std::string::npos || name_.find("wm") != std::string::npos || name_.find("wm") != std::string::npos){
+    if (name_.find("we") != std::string::npos ||
+        name_.find("wm") != std::string::npos ||
+        name_.find("wm") != std::string::npos) {
         isW_ = true;
-    }
-    else if (name_.find("DYm50") != std::string::npos){
+    } else if (name_.find("DYm50") != std::string::npos) {
         isZ_ = true;
     }
     SelectorBase::Init(tree);
@@ -23,28 +23,29 @@ void LowPileupSelector::SetBranchesBacon() {
     b.SetBranch("scale1fb", scale1fb);
 }
 
-void LowPileupSelector::LoadBranchesBacon(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void LowPileupSelector::LoadBranchesBacon(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     weight = 1;
     b.SetEntry(entry);
 
     if (isMC_) {
-        weight = scale1fb*1000;
-        //weight = genWeight*PUWeight*scale1fb;
+        weight = scale1fb * 1000;
+        // weight = genWeight*PUWeight*scale1fb;
     }
     SetComposite();
 }
 
 void LowPileupSelector::SetupNewDirectory() {
     SelectorBase::SetupNewDirectory();
-    if (name_.find("__m") != std::string::npos || name_.find("__tm") != std::string::npos) {
+    if (name_.find("__m") != std::string::npos ||
+        name_.find("__tm") != std::string::npos) {
         allChannels_ = {{mp, "mp"}, {mn, "mn"}};
         isE_ = false;
-    }
-    else if (name_.find("__e") != std::string::npos || name_.find("__te") != std::string::npos) {
+    } else if (name_.find("__e") != std::string::npos ||
+               name_.find("__te") != std::string::npos) {
         allChannels_ = {{ep, "ep"}, {en, "en"}};
         isE_ = true;
     }
 
     InitializeHistogramsFromConfig();
 }
-

--- a/src/LowPileupWBackgroundSelector.cc
+++ b/src/LowPileupWBackgroundSelector.cc
@@ -2,26 +2,26 @@
 #include <TStyle.h>
 #include <regex>
 
-void LowPileupWBackgroundSelector::Init(TTree *tree) {
+void LowPileupWBackgroundSelector::Init(TTree* tree) {
     isNonprompt_ = true;
     LowPileupWSelector::Init(tree);
 }
 
-void LowPileupWBackgroundSelector::FillHistograms(Long64_t entry, SystPair variation) { 
+void LowPileupWBackgroundSelector::FillHistograms(Long64_t entry,
+                                                  SystPair variation) {
     if ((!isE_ && *lepRelIso > 0.25 && *lepRelIso < 0.35) ||
-            (isE_ && *lepRelIso > 0.3 && *lepRelIso < 0.45))
+        (isE_ && *lepRelIso > 0.3 && *lepRelIso < 0.45))
         return;
-    //weight *= (isE_ ? 2. : 0.13);
+    // weight *= (isE_ ? 2. : 0.13);
     LowPileupWSelector::FillHistograms(entry, variation);
 }
 
 void LowPileupWBackgroundSelector::SetupNewDirectory() {
     LowPileupWSelector::SetupNewDirectory();
 
-    for (const auto && obj : *currentHistDir_) {
+    for (const auto&& obj : *currentHistDir_) {
         std::string name = obj->GetName();
         TNamed* named = dynamic_cast<TNamed*>(obj);
-        named->SetName(name.insert(name.length()-2, "Fakes_").c_str());
+        named->SetName(name.insert(name.length() - 2, "Fakes_").c_str());
     }
-    
 }

--- a/src/LowPileupWSelector.cc
+++ b/src/LowPileupWSelector.cc
@@ -3,14 +3,17 @@
 #include <regex>
 #include "TParameter.h"
 
-void LowPileupWSelector::Init(TTree *tree)
-{
-    TParameter<bool>* doSyst = (TParameter<bool>*) GetInputList()->FindObject("doSyst");
+void LowPileupWSelector::Init(TTree* tree) {
+    TParameter<bool>* doSyst =
+        (TParameter<bool>*)GetInputList()->FindObject("doSyst");
     doSystematics_ = doSyst != nullptr && doSyst->GetVal();
     std::cout << "INFO: doSystematics is " << doSystematics_ << std::endl;
     allChannels_ = {{ep, "ep"}, {en, "en"}, {mp, "mp"}, {mn, "mn"}};
 
-    hists1D_ = {"CutFlow", "mW", "mtW", "mtWUncorr", "yW", "ptW", "phiW", "ptl", "etal", "pfMet", "pfMetPhi",};
+    hists1D_ = {
+        "CutFlow", "mW",  "mtW",  "mtWUncorr", "yW",       "ptW",
+        "phiW",    "ptl", "etal", "pfMet",     "pfMetPhi",
+    };
     systHists_ = {"ptW", "ptl", "mtW", "pfMet"};
     systematics_ = {
         {muonEfficiencyMCSubtractUp, "CMS_eff_MCsubt_mUp"},
@@ -24,34 +27,34 @@ void LowPileupWSelector::Init(TTree *tree)
         {muonEfficiencyStatUp, "CMS_eff_stat_mUp"},
         {muonEfficiencyStatDown, "CMS_eff_stat_mDown"},
         {recoilCorrectionEtaShapeUp, "CMS_recoilCorrection_EtaShapeUp"},
-        {recoilCorrectionRUShapesUp, "CMS_recoilCorrection_RUShapeUp"}, 
+        {recoilCorrectionRUShapesUp, "CMS_recoilCorrection_RUShapeUp"},
         {recoilCorrectionKeysShapeUp, "CMS_recoilCorrection_KeysShapeUp"},
-        {recoilCorrectionStat0Up, "CMS_recoilCorrection_StatBin0Up"},    
-        {recoilCorrectionStat1Up, "CMS_recoilCorrection_StatBin1Up"},    
-        {recoilCorrectionStat2Up, "CMS_recoilCorrection_StatBin2Up"},        
-        {recoilCorrectionStat3Up, "CMS_recoilCorrection_StatBin3Up"},        
-        {recoilCorrectionStat4Up, "CMS_recoilCorrection_StatBin4Up"},        
-        {recoilCorrectionStat5Up, "CMS_recoilCorrection_StatBin5Up"},        
-        {recoilCorrectionStat6Up, "CMS_recoilCorrection_StatBin6Up"},        
-        {recoilCorrectionStat7Up, "CMS_recoilCorrection_StatBin7Up"},        
-        {recoilCorrectionStat8Up, "CMS_recoilCorrection_StatBin8Up"},        
-        {recoilCorrectionStat9Up, "CMS_recoilCorrection_StatBin9Up"},        
+        {recoilCorrectionStat0Up, "CMS_recoilCorrection_StatBin0Up"},
+        {recoilCorrectionStat1Up, "CMS_recoilCorrection_StatBin1Up"},
+        {recoilCorrectionStat2Up, "CMS_recoilCorrection_StatBin2Up"},
+        {recoilCorrectionStat3Up, "CMS_recoilCorrection_StatBin3Up"},
+        {recoilCorrectionStat4Up, "CMS_recoilCorrection_StatBin4Up"},
+        {recoilCorrectionStat5Up, "CMS_recoilCorrection_StatBin5Up"},
+        {recoilCorrectionStat6Up, "CMS_recoilCorrection_StatBin6Up"},
+        {recoilCorrectionStat7Up, "CMS_recoilCorrection_StatBin7Up"},
+        {recoilCorrectionStat8Up, "CMS_recoilCorrection_StatBin8Up"},
+        {recoilCorrectionStat9Up, "CMS_recoilCorrection_StatBin9Up"},
         {recoilCorrectionEtaShapeDown, "CMS_recoilCorrection_EtaShapeDown"},
-        {recoilCorrectionRUShapesDown, "CMS_recoilCorrection_RUShapeDown"}, 
+        {recoilCorrectionRUShapesDown, "CMS_recoilCorrection_RUShapeDown"},
         {recoilCorrectionKeysShapeDown, "CMS_recoilCorrection_KeysShapeDown"},
-        {recoilCorrectionStat0Down, "CMS_recoilCorrection_StatBin0Down"},    
-        {recoilCorrectionStat1Down, "CMS_recoilCorrection_StatBin1Down"},    
-        {recoilCorrectionStat2Down, "CMS_recoilCorrection_StatBin2Down"},        
-        {recoilCorrectionStat3Down, "CMS_recoilCorrection_StatBin3Down"},        
-        {recoilCorrectionStat4Down, "CMS_recoilCorrection_StatBin4Down"},        
-        {recoilCorrectionStat5Down, "CMS_recoilCorrection_StatBin5Down"},        
-        {recoilCorrectionStat6Down, "CMS_recoilCorrection_StatBin6Down"},        
-        {recoilCorrectionStat7Down, "CMS_recoilCorrection_StatBin7Down"},        
-        {recoilCorrectionStat8Down, "CMS_recoilCorrection_StatBin8Down"},        
-        {recoilCorrectionStat9Down, "CMS_recoilCorrection_StatBin9Down"},        
+        {recoilCorrectionStat0Down, "CMS_recoilCorrection_StatBin0Down"},
+        {recoilCorrectionStat1Down, "CMS_recoilCorrection_StatBin1Down"},
+        {recoilCorrectionStat2Down, "CMS_recoilCorrection_StatBin2Down"},
+        {recoilCorrectionStat3Down, "CMS_recoilCorrection_StatBin3Down"},
+        {recoilCorrectionStat4Down, "CMS_recoilCorrection_StatBin4Down"},
+        {recoilCorrectionStat5Down, "CMS_recoilCorrection_StatBin5Down"},
+        {recoilCorrectionStat6Down, "CMS_recoilCorrection_StatBin6Down"},
+        {recoilCorrectionStat7Down, "CMS_recoilCorrection_StatBin7Down"},
+        {recoilCorrectionStat8Down, "CMS_recoilCorrection_StatBin8Down"},
+        {recoilCorrectionStat9Down, "CMS_recoilCorrection_StatBin9Down"},
     };
-    
-    //enum{mc=1,fsr,bkg,tagpt,effstat,pfireu,pfired};
+
+    // enum{mc=1,fsr,bkg,tagpt,effstat,pfireu,pfired};
     systematicWeightMap_ = {
         {Central, 0},
         {muonEfficiencyMCSubtractUp, 1},
@@ -67,32 +70,19 @@ void LowPileupWSelector::Init(TTree *tree)
     };
 
     metCorrWeightMap_ = {
-        {recoilCorrectionEtaShapeUp, 2},
-        {recoilCorrectionRUShapesUp, 3}, 
-        {recoilCorrectionKeysShapeUp, 4},
-        {recoilCorrectionStat0Up, 5},    
-        {recoilCorrectionStat1Up, 6},    
-        {recoilCorrectionStat2Up, 7},        
-        {recoilCorrectionStat3Up, 8},        
-        {recoilCorrectionStat4Up, 9},        
-        {recoilCorrectionStat5Up, 10},        
-        {recoilCorrectionStat6Up, 11},        
-        {recoilCorrectionStat7Up, 12},        
-        {recoilCorrectionStat8Up, 13},        
-        {recoilCorrectionStat9Up, 14},        
-        {recoilCorrectionEtaShapeDown, 2},
-        {recoilCorrectionRUShapesDown, 3}, 
-        {recoilCorrectionKeysShapeDown, 4},
-        {recoilCorrectionStat0Down, 5},    
-        {recoilCorrectionStat1Down, 6},    
-        {recoilCorrectionStat2Down, 7},        
-        {recoilCorrectionStat3Down, 8},        
-        {recoilCorrectionStat4Down, 9},        
-        {recoilCorrectionStat5Down, 10},        
-        {recoilCorrectionStat6Down, 11},        
-        {recoilCorrectionStat7Down, 12},        
-        {recoilCorrectionStat8Down, 13},        
-        {recoilCorrectionStat9Down, 14},        
+        {recoilCorrectionEtaShapeUp, 2},   {recoilCorrectionRUShapesUp, 3},
+        {recoilCorrectionKeysShapeUp, 4},  {recoilCorrectionStat0Up, 5},
+        {recoilCorrectionStat1Up, 6},      {recoilCorrectionStat2Up, 7},
+        {recoilCorrectionStat3Up, 8},      {recoilCorrectionStat4Up, 9},
+        {recoilCorrectionStat5Up, 10},     {recoilCorrectionStat6Up, 11},
+        {recoilCorrectionStat7Up, 12},     {recoilCorrectionStat8Up, 13},
+        {recoilCorrectionStat9Up, 14},     {recoilCorrectionEtaShapeDown, 2},
+        {recoilCorrectionRUShapesDown, 3}, {recoilCorrectionKeysShapeDown, 4},
+        {recoilCorrectionStat0Down, 5},    {recoilCorrectionStat1Down, 6},
+        {recoilCorrectionStat2Down, 7},    {recoilCorrectionStat3Down, 8},
+        {recoilCorrectionStat4Down, 9},    {recoilCorrectionStat5Down, 10},
+        {recoilCorrectionStat6Down, 11},   {recoilCorrectionStat7Down, 12},
+        {recoilCorrectionStat8Down, 13},   {recoilCorrectionStat9Down, 14},
     };
 
     fReader.SetTree(tree);
@@ -103,28 +93,25 @@ void LowPileupWSelector::SetBranchesBacon() {
     LowPileupSelector::SetBranchesBacon();
 }
 
-void LowPileupWSelector::LoadBranchesBacon(Long64_t entry, SystPair variation) { 
+void LowPileupWSelector::LoadBranchesBacon(Long64_t entry, SystPair variation) {
     if (variation.first == Central) {
         fReader.SetLocalEntry(entry);
         LowPileupSelector::LoadBranchesBacon(entry, variation);
         if (*charge > 0) {
             // This is probably not safe at all
             if (isE_) {
-                channel_ = ep ;
+                channel_ = ep;
                 channelName_ = "ep";
-            }
-            else {
-                channel_ = mp ;
+            } else {
+                channel_ = mp;
                 channelName_ = "mp";
             }
-        }
-        else {
+        } else {
             if (isE_) {
-                channel_ = en ;
+                channel_ = en;
                 channelName_ = "en";
-            }
-            else {
-                channel_ = mn ;
+            } else {
+                channel_ = mn;
                 channelName_ = "mn";
             }
         }
@@ -141,54 +128,55 @@ void LowPileupWSelector::LoadBranchesBacon(Long64_t entry, SystPair variation) {
         float wgt = evtWeight[systematicWeightMap_[variation.first]];
         weight = cenwgt;
         if (variation.first == muonEfficiencyMCSubtractUp ||
-                    variation.first == muonEfficiencyBackgroundUp ||
-                    variation.first == muonEfficiencyTagPtUp ||
-                    variation.first == muonEfficiencyStatUp ||
-                    variation.first == modelingFsrUp) {
-            weight = wgt > cenwgt ? wgt : cenwgt + std::abs(cenwgt-wgt);
-        }
-        else if (variation.first == muonEfficiencyMCSubtractDown ||
-                    variation.first == muonEfficiencyBackgroundDown ||
-                    variation.first == muonEfficiencyTagPtDown ||
-                    variation.first == muonEfficiencyStatDown ||
-                    variation.first == modelingFsrDown) {
-            weight = wgt < cenwgt ? wgt : cenwgt - std::abs(cenwgt-wgt);
-        }
-        else if (variation.first == recoilCorrectionEtaShapeUp ||
-                variation.first == recoilCorrectionRUShapesUp ||
-                variation.first == recoilCorrectionKeysShapeUp ||
-                variation.first == recoilCorrectionStat0Up || 
-                variation.first == recoilCorrectionStat1Up || 
-                variation.first == recoilCorrectionStat2Up || 
-                variation.first == recoilCorrectionStat3Up || 
-                variation.first == recoilCorrectionStat4Up || 
-                variation.first == recoilCorrectionStat5Up || 
-                variation.first == recoilCorrectionStat6Up || 
-                variation.first == recoilCorrectionStat7Up || 
-                variation.first == recoilCorrectionStat8Up || 
-                variation.first == recoilCorrectionStat9Up) {
+            variation.first == muonEfficiencyBackgroundUp ||
+            variation.first == muonEfficiencyTagPtUp ||
+            variation.first == muonEfficiencyStatUp ||
+            variation.first == modelingFsrUp) {
+            weight = wgt > cenwgt ? wgt : cenwgt + std::abs(cenwgt - wgt);
+        } else if (variation.first == muonEfficiencyMCSubtractDown ||
+                   variation.first == muonEfficiencyBackgroundDown ||
+                   variation.first == muonEfficiencyTagPtDown ||
+                   variation.first == muonEfficiencyStatDown ||
+                   variation.first == modelingFsrDown) {
+            weight = wgt < cenwgt ? wgt : cenwgt - std::abs(cenwgt - wgt);
+        } else if (variation.first == recoilCorrectionEtaShapeUp ||
+                   variation.first == recoilCorrectionRUShapesUp ||
+                   variation.first == recoilCorrectionKeysShapeUp ||
+                   variation.first == recoilCorrectionStat0Up ||
+                   variation.first == recoilCorrectionStat1Up ||
+                   variation.first == recoilCorrectionStat2Up ||
+                   variation.first == recoilCorrectionStat3Up ||
+                   variation.first == recoilCorrectionStat4Up ||
+                   variation.first == recoilCorrectionStat5Up ||
+                   variation.first == recoilCorrectionStat6Up ||
+                   variation.first == recoilCorrectionStat7Up ||
+                   variation.first == recoilCorrectionStat8Up ||
+                   variation.first == recoilCorrectionStat9Up) {
             double tempMet = metVector.At(metCorrWeightMap_[variation.first]);
-            double tempMetPhi = metPhiVector.At(metCorrWeightMap_[variation.first]);
+            double tempMetPhi =
+                metPhiVector.At(metCorrWeightMap_[variation.first]);
             pfMet = tempMet > pfMet ? tempMet : pfMet + (pfMet - tempMet);
-            pfMetPhi = tempMet > pfMet ? tempMetPhi : pfMetPhi + (pfMetPhi - tempMetPhi);
-        }
-        else if (variation.first == recoilCorrectionEtaShapeDown ||
-                variation.first == recoilCorrectionRUShapesDown ||
-                variation.first == recoilCorrectionKeysShapeDown ||
-                variation.first == recoilCorrectionStat0Down || 
-                variation.first == recoilCorrectionStat1Down || 
-                variation.first == recoilCorrectionStat2Down || 
-                variation.first == recoilCorrectionStat3Down || 
-                variation.first == recoilCorrectionStat4Down || 
-                variation.first == recoilCorrectionStat5Down || 
-                variation.first == recoilCorrectionStat6Down || 
-                variation.first == recoilCorrectionStat7Down || 
-                variation.first == recoilCorrectionStat8Down || 
-                variation.first == recoilCorrectionStat9Down) {
+            pfMetPhi = tempMet > pfMet ? tempMetPhi
+                                       : pfMetPhi + (pfMetPhi - tempMetPhi);
+        } else if (variation.first == recoilCorrectionEtaShapeDown ||
+                   variation.first == recoilCorrectionRUShapesDown ||
+                   variation.first == recoilCorrectionKeysShapeDown ||
+                   variation.first == recoilCorrectionStat0Down ||
+                   variation.first == recoilCorrectionStat1Down ||
+                   variation.first == recoilCorrectionStat2Down ||
+                   variation.first == recoilCorrectionStat3Down ||
+                   variation.first == recoilCorrectionStat4Down ||
+                   variation.first == recoilCorrectionStat5Down ||
+                   variation.first == recoilCorrectionStat6Down ||
+                   variation.first == recoilCorrectionStat7Down ||
+                   variation.first == recoilCorrectionStat8Down ||
+                   variation.first == recoilCorrectionStat9Down) {
             double tempMet = metVector.At(metCorrWeightMap_[variation.first]);
-            double tempMetPhi = metPhiVector.At(metCorrWeightMap_[variation.first]);
+            double tempMetPhi =
+                metPhiVector.At(metCorrWeightMap_[variation.first]);
             pfMet = tempMet < pfMet ? tempMet : pfMet - (tempMet - pfMet);
-            pfMetPhi = tempMet < pfMet ? tempMetPhi : pfMetPhi - (tempMetPhi - pfMetPhi);
+            pfMetPhi = tempMet < pfMet ? tempMetPhi
+                                       : pfMetPhi - (tempMetPhi - pfMetPhi);
         }
     }
 }
@@ -197,37 +185,47 @@ void LowPileupWSelector::SetComposite() {
     pfMetVec = TLorentzVector();
     pfMetVec.SetPtEtaPhiM(pfMet, 0., pfMetPhi, 0.);
     wCand = *lep + pfMetVec;
-    //mtW = std::sqrt(2*lep->Pt()*pfMet*(1-std::cos(lep->Phi()-pfMetVec.Phi())));
+    // mtW =
+    // std::sqrt(2*lep->Pt()*pfMet*(1-std::cos(lep->Phi()-pfMetVec.Phi())));
 }
 
-void LowPileupWSelector::FillHistograms(Long64_t entry, SystPair variation) { 
-    if (lep->Pt() < 25 || *mtW < 40)
-        return;
-    SafeHistFill(histMap1D_, "mW", channel_, variation.first, wCand.M(), weight);
+void LowPileupWSelector::FillHistograms(Long64_t entry, SystPair variation) {
+    if (lep->Pt() < 25 || *mtW < 40) return;
+    SafeHistFill(histMap1D_, "mW", channel_, variation.first, wCand.M(),
+                 weight);
     SafeHistFill(histMap1D_, "mtW", channel_, variation.first, *mtW, weight);
-    SafeHistFill(histMap1D_, "mtWUncorr", channel_, variation.first, *mtWuncorr, weight);
-    SafeHistFill(histMap1D_, "ptW", channel_, variation.first, wCand.Pt(), weight);
-    SafeHistFill(histMap1D_, "yW", channel_, variation.first, wCand.Rapidity(), weight);
-    SafeHistFill(histMap1D_, "phiW", channel_, variation.first, wCand.Phi(), weight);
-    SafeHistFill(histMap1D_, "ptl", channel_, variation.first, lep->Pt(), weight);
-    SafeHistFill(histMap1D_, "etal", channel_, variation.first, lep->Eta(), weight);
+    SafeHistFill(histMap1D_, "mtWUncorr", channel_, variation.first, *mtWuncorr,
+                 weight);
+    SafeHistFill(histMap1D_, "ptW", channel_, variation.first, wCand.Pt(),
+                 weight);
+    SafeHistFill(histMap1D_, "yW", channel_, variation.first, wCand.Rapidity(),
+                 weight);
+    SafeHistFill(histMap1D_, "phiW", channel_, variation.first, wCand.Phi(),
+                 weight);
+    SafeHistFill(histMap1D_, "ptl", channel_, variation.first, lep->Pt(),
+                 weight);
+    SafeHistFill(histMap1D_, "etal", channel_, variation.first, lep->Eta(),
+                 weight);
     SafeHistFill(histMap1D_, "pfMet", channel_, variation.first, pfMet, weight);
-    SafeHistFill(histMap1D_, "pfMetPhi", channel_, variation.first, pfMetPhi, weight);
+    SafeHistFill(histMap1D_, "pfMetPhi", channel_, variation.first, pfMetPhi,
+                 weight);
 
     if (subprocessHistMaps1D_.empty()) {
         return;
     }
 
-    //std::vector<int> binning = {0, 13, 26, 38, 50, 62, 75, 100};
+    // std::vector<int> binning = {0, 13, 26, 38, 50, 62, 75, 100};
     std::vector<int> binning = {0, 5, 10, 15, 20, 25, 30, 40, 50, 60, 75, 100};
-    size_t upperIndex = std::distance(binning.begin(), std::upper_bound(binning.begin(), binning.end(), genVPt));
+    size_t upperIndex =
+        std::distance(binning.begin(),
+                      std::upper_bound(binning.begin(), binning.end(), genVPt));
 
-    std::string binname = name_.substr(0, name_.size()-3);
+    std::string binname = name_.substr(0, name_.size() - 3);
     binname.append("_GenPtW_");
     if (upperIndex == binning.size())
         binname.append(std::to_string(binning.back()));
     else {
-        binname.append(std::to_string(binning.at(upperIndex-1)));
+        binname.append(std::to_string(binning.at(upperIndex - 1)));
         binname.append("_");
         binname.append(std::to_string(binning.at(upperIndex)));
     }
@@ -235,14 +233,20 @@ void LowPileupWSelector::FillHistograms(Long64_t entry, SystPair variation) {
 
     try {
         HistMap1D& subprocessMap = subprocessHistMaps1D_.at(binname);
-        SafeHistFill(subprocessMap, "mW", channel_, variation.first, wCand.M(), weight);
-        SafeHistFill(subprocessMap, "ptW", channel_, variation.first, wCand.Pt(), weight);
-        SafeHistFill(subprocessMap, "yW", channel_, variation.first, wCand.Rapidity(), weight);
-        SafeHistFill(subprocessMap, "ptl", channel_, variation.first, lep->Pt(), weight);
-        SafeHistFill(subprocessMap, "etal", channel_, variation.first, lep->Eta(), weight);
-        SafeHistFill(subprocessMap, "pfMet", channel_, variation.first, pfMet, weight);
-    }
-    catch (std::exception& e) {
-        throw std::range_error("Could not find bin " + binname + " in subprocessMap!");
+        SafeHistFill(subprocessMap, "mW", channel_, variation.first, wCand.M(),
+                     weight);
+        SafeHistFill(subprocessMap, "ptW", channel_, variation.first,
+                     wCand.Pt(), weight);
+        SafeHistFill(subprocessMap, "yW", channel_, variation.first,
+                     wCand.Rapidity(), weight);
+        SafeHistFill(subprocessMap, "ptl", channel_, variation.first, lep->Pt(),
+                     weight);
+        SafeHistFill(subprocessMap, "etal", channel_, variation.first,
+                     lep->Eta(), weight);
+        SafeHistFill(subprocessMap, "pfMet", channel_, variation.first, pfMet,
+                     weight);
+    } catch (std::exception& e) {
+        throw std::range_error("Could not find bin " + binname +
+                               " in subprocessMap!");
     }
 }

--- a/src/LowPileupZSelector.cc
+++ b/src/LowPileupZSelector.cc
@@ -2,10 +2,11 @@
 #include <TStyle.h>
 #include <regex>
 
-void LowPileupZSelector::Init(TTree *tree)
-{
+void LowPileupZSelector::Init(TTree *tree) {
     allChannels_ = {{mm, "mm"}};
-    hists1D_ = {"CutFlow", "mZ", "yZ", "ptZ", "ptl1", "etal1", "ptl2", "etal2", "pfMet",};
+    hists1D_ = {
+        "CutFlow", "mZ", "yZ", "ptZ", "ptl1", "etal1", "ptl2", "etal2", "pfMet",
+    };
 
     LowPileupSelector::Init(tree);
 }
@@ -27,27 +28,28 @@ void LowPileupZSelector::SetBranchesBacon() {
     LowPileupSelector::SetBranchesBacon();
 }
 
-void LowPileupZSelector::LoadBranchesBacon(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void LowPileupZSelector::LoadBranchesBacon(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     lep1_b->GetEntry(entry);
     lep2_b->GetEntry(entry);
     LowPileupSelector::LoadBranchesBacon(entry, variation);
 }
 
-void LowPileupZSelector::SetComposite() {
-    zCand = *lep1+*lep2;
-}
+void LowPileupZSelector::SetComposite() { zCand = *lep1 + *lep2; }
 
-void LowPileupZSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
-    if (zCand.M() < 60 || zCand.M() > 120)
-        return;
-    if (category != eMuMu1HLT && category != eMuMu2HLT)
-        return;
-    //SafeHistFill(histMap1D_, getHistName("mZ", variation.second), zCand.M(), weight);
-    //SafeHistFill(histMap1D_, getHistName("ptZ", variation.second), zCand.Pt(), weight);
-    //SafeHistFill(histMap1D_, getHistName("yZ", variation.second), zCand.Rapidity(), weight);
-    //SafeHistFill(histMap1D_, getHistName("ptl1", variation.second), lep1->Pt(), weight);
-    //SafeHistFill(histMap1D_, getHistName("ptl2", variation.second), lep2->Pt(), weight);
-    //SafeHistFill(histMap1D_, getHistName("etal1", variation.second), lep1->Eta(), weight);
-    //SafeHistFill(histMap1D_, getHistName("etal2", variation.second), lep2->Eta(), weight);
-    //SafeHistFill(histMap1D_, getHistName("pfMet", variation.second), pfMet, weight);
+void LowPileupZSelector::FillHistograms(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
+    if (zCand.M() < 60 || zCand.M() > 120) return;
+    if (category != eMuMu1HLT && category != eMuMu2HLT) return;
+    // SafeHistFill(histMap1D_, getHistName("mZ", variation.second), zCand.M(),
+    // weight); SafeHistFill(histMap1D_, getHistName("ptZ", variation.second),
+    // zCand.Pt(), weight); SafeHistFill(histMap1D_, getHistName("yZ",
+    // variation.second), zCand.Rapidity(), weight); SafeHistFill(histMap1D_,
+    // getHistName("ptl1", variation.second), lep1->Pt(), weight);
+    // SafeHistFill(histMap1D_, getHistName("ptl2", variation.second),
+    // lep2->Pt(), weight); SafeHistFill(histMap1D_, getHistName("etal1",
+    // variation.second), lep1->Eta(), weight); SafeHistFill(histMap1D_,
+    // getHistName("etal2", variation.second), lep2->Eta(), weight);
+    // SafeHistFill(histMap1D_, getHistName("pfMet", variation.second), pfMet,
+    // weight);
 }

--- a/src/NanoGenSelectorBase.cc
+++ b/src/NanoGenSelectorBase.cc
@@ -1,18 +1,20 @@
 #include "Analysis/VVAnalysis/interface/NanoGenSelectorBase.h"
-#include "PhysicsTools/HepMCCandAlgos/interface/PDFWeightsHelper.h"
-#include "DataFormats/Math/interface/deltaR.h"
-#include "TParameter.h"
 #include <TStyle.h>
 #include <regex>
+#include "DataFormats/Math/interface/deltaR.h"
+#include "PhysicsTools/HepMCCandAlgos/interface/PDFWeightsHelper.h"
+#include "TParameter.h"
 
-void NanoGenSelectorBase::Init(TTree *tree)
-{
+void NanoGenSelectorBase::Init(TTree* tree) {
     refWeight = 1;
-    TParameter<bool>* doTheory = (TParameter<bool>*) GetInputList()->FindObject("theoryUnc");
+    TParameter<bool>* doTheory =
+        (TParameter<bool>*)GetInputList()->FindObject("theoryUnc");
     doTheoryVars_ = doTheory != nullptr && doTheory->GetVal();
-    TParameter<bool>* wSignOnly = (TParameter<bool>*) GetInputList()->FindObject("wSignOnly");
+    TParameter<bool>* wSignOnly =
+        (TParameter<bool>*)GetInputList()->FindObject("wSignOnly");
     weightSignOnly_ = wSignOnly != nullptr && wSignOnly->GetVal();
-    TParameter<int>* wSuppress = (TParameter<int>*) GetInputList()->FindObject("wSuppress");
+    TParameter<int>* wSuppress =
+        (TParameter<int>*)GetInputList()->FindObject("wSuppress");
     weightSuppress_ = wSuppress != nullptr ? wSuppress->GetVal() : 0;
 
     if (doTheoryVars_) {
@@ -23,22 +25,19 @@ void NanoGenSelectorBase::Init(TTree *tree)
         theoryVarSysts_.insert(theoryVarSysts_.end(), mZShift100MeVDown);
     }
 
-    TParameter<bool>* doPtVSplit = (TParameter<bool>*) GetInputList()->FindObject("theoryPtV");
+    TParameter<bool>* doPtVSplit =
+        (TParameter<bool>*)GetInputList()->FindObject("theoryPtV");
     if (doTheoryVars_ && doPtVSplit != nullptr && doPtVSplit->GetVal()) {
         // For now it's based on the LHE kinematics
-        TNamed* selection = (TNamed *) GetInputList()->FindObject("selection");
-        std::string selectionName = selection == nullptr ? "" : selection->GetTitle();
+        TNamed* selection = (TNamed*)GetInputList()->FindObject("selection");
+        std::string selectionName =
+            selection == nullptr ? "" : selection->GetTitle();
         SystMap ptvars = {
-            {ptV0to3, "ptV0to3"},
-            {ptV3to5, "ptV3to5"},
-            {ptV5to7, "ptV5to7"},
-            {ptV7to9, "ptV7to9"},
-            {ptV9to12, "ptV9to12"},
-            {ptV12to15, "ptV12to15"},
-            {ptV15to20, "ptV15to20"},
-            {ptV20to27, "ptV20to27"},
-            {ptV27to40, "ptV27to40"},
-            {ptV40toInf, "ptV40toInf"},
+            {ptV0to3, "ptV0to3"},     {ptV3to5, "ptV3to5"},
+            {ptV5to7, "ptV5to7"},     {ptV7to9, "ptV7to9"},
+            {ptV9to12, "ptV9to12"},   {ptV12to15, "ptV12to15"},
+            {ptV15to20, "ptV15to20"}, {ptV20to27, "ptV20to27"},
+            {ptV27to40, "ptV27to40"}, {ptV40toInf, "ptV40toInf"},
         };
         if (selectionName == "None") {
             ptvars = {
@@ -60,31 +59,38 @@ void NanoGenSelectorBase::Init(TTree *tree)
         }
     }
     b.SetTree(tree);
-    altScaleWeights_ = (tree->GetListOfBranches()->FindObject("nLHEScaleWeightAltSet1") != nullptr);
-    unknownWeights_ = (tree->GetListOfBranches()->FindObject("nLHEUnknownWeight") != nullptr);
-    unknownWeightsAlt_ = (tree->GetListOfBranches()->FindObject("nLHEUnknownWeightAltSet1") != nullptr);
-    pdfWeights_ = (tree->GetListOfBranches()->FindObject("nLHEPdfWeight") != nullptr);
+    altScaleWeights_ = (tree->GetListOfBranches()->FindObject(
+                            "nLHEScaleWeightAltSet1") != nullptr);
+    unknownWeights_ =
+        (tree->GetListOfBranches()->FindObject("nLHEUnknownWeight") != nullptr);
+    unknownWeightsAlt_ = (tree->GetListOfBranches()->FindObject(
+                              "nLHEUnknownWeightAltSet1") != nullptr);
+    pdfWeights_ =
+        (tree->GetListOfBranches()->FindObject("nLHEPdfWeight") != nullptr);
 
     SelectorBase::Init(tree);
 
-    edm::FileInPath mc2hessianCSV("PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv");
+    edm::FileInPath mc2hessianCSV(
+        "PhysicsTools/HepMCCandAlgos/data/NNPDF30_lo_as_0130_hessian_60.csv");
     // Off for now
     doMC2H_ = name_.find("cp5") == std::string::npos && false;
     if (doMC2H_) {
-        std::cout << "INFO: Will convert MC PDF set to Hessian with MC2Hessian\n";
-        pdfweightshelper_.Init(N_LHEPDF_WEIGHTS_, N_MC2HESSIAN_WEIGHTS_, mc2hessianCSV);
+        std::cout
+            << "INFO: Will convert MC PDF set to Hessian with MC2Hessian\n";
+        pdfweightshelper_.Init(N_LHEPDF_WEIGHTS_, N_MC2HESSIAN_WEIGHTS_,
+                               mc2hessianCSV);
     }
     centralWeightIndex_ = -1;
     // NNLOPSLike is just a config name for one MiNNLO sample
-    if (name_.find("nnlops") != std::string::npos && name_.find("nnlopslike") == std::string::npos) {
+    if (name_.find("nnlops") != std::string::npos &&
+        name_.find("nnlopslike") == std::string::npos) {
         if (name_.find("nloOnly") == std::string::npos) {
             centralWeightIndex_ = 9;
-            std::cout << "INFO: NNLOPS sample will be weighted by NNLO weight\n";
-        }
-        else
+            std::cout
+                << "INFO: NNLOPS sample will be weighted by NNLO weight\n";
+        } else
             std::cout << "INFO: Found NNLOPS sample but not applying weight\n";
-    }
-    else if (name_.find("ref_nnpdf31") != std::string::npos) {
+    } else if (name_.find("ref_nnpdf31") != std::string::npos) {
         centralWeightIndex_ = 0;
         std::cout << "INFO: Sample will be weighted by 1st LHE weight\n";
     }
@@ -92,8 +98,10 @@ void NanoGenSelectorBase::Init(TTree *tree)
     doFiducial_ = selection_ != None;
     if (!doFiducial_)
         std::cout << "INFO: No fiducial selection will be applied\n";
-    //doBorn_ = std::find_if(systematics_.begin(), systematics_.end(), [](auto& s) { return s.first == BornParticles; }) != systematics_.end();
-    //doBareLeptons_ = std::find_if(systematics_.begin(), systematics_.end(), [](auto& s) { return s.first == BareLeptons; }) != systematics_.end();
+    // doBorn_ = std::find_if(systematics_.begin(), systematics_.end(), [](auto&
+    // s) { return s.first == BornParticles; }) != systematics_.end();
+    // doBareLeptons_ = std::find_if(systematics_.begin(), systematics_.end(),
+    // [](auto& s) { return s.first == BareLeptons; }) != systematics_.end();
     doBorn_ = true;
     doBareLeptons_ = true;
     fReader.SetTree(tree);
@@ -112,13 +120,16 @@ void NanoGenSelectorBase::SetBranchesNanoAOD() {
         b.SetSpecificBranch("nLHEUnknownWeight", nLHEUnknownWeight);
         b.SetSpecificBranch("LHEUnknownWeight", LHEUnknownWeight);
         if (unknownWeightsAlt_) {
-            b.SetSpecificBranch("nLHEUnknownWeightAltSet1", nLHEUnknownWeightAltSet1);
-            b.SetSpecificBranch("LHEUnknownWeightAltSet1", LHEUnknownWeightAltSet1);
+            b.SetSpecificBranch("nLHEUnknownWeightAltSet1",
+                                nLHEUnknownWeightAltSet1);
+            b.SetSpecificBranch("LHEUnknownWeightAltSet1",
+                                LHEUnknownWeightAltSet1);
         }
     }
 }
 
-void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation) { 
+void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry,
+                                              SystPair variation) {
     weight = 1;
     if (altScaleWeights_) {
         b.SetSpecificEntry(entry, "nLHEScaleWeightAltSet1");
@@ -137,25 +148,24 @@ void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation
         }
     }
 
-    if (!altScaleWeights_)
-        nLHEScaleWeightAltSet1 = 0;
-    if (!pdfWeights_)
-        nLHEPdfWeight = 0;
-    if (!unknownWeights_)
-        nLHEUnknownWeight = 0;
-    if (!unknownWeightsAlt_)
-        nLHEUnknownWeightAltSet1 = 0;
+    if (!altScaleWeights_) nLHEScaleWeightAltSet1 = 0;
+    if (!pdfWeights_) nLHEPdfWeight = 0;
+    if (!unknownWeights_) nLHEUnknownWeight = 0;
+    if (!unknownWeightsAlt_) nLHEUnknownWeightAltSet1 = 0;
     fReader.SetLocalEntry(entry);
 
     channel_ = channelMap_[channelName_];
 
     // Sort descending
-    auto compareMaxByPt = [](const reco::GenParticle& a, const reco::GenParticle& b) { return a.pt() > b.pt(); };
+    auto compareMaxByPt = [](const reco::GenParticle& a,
+                             const reco::GenParticle& b) {
+        return a.pt() > b.pt();
+    };
     std::vector<unsigned int> idsToKeep = {11, 12, 13, 14};
-    if (doPhotons_)
-        idsToKeep.push_back(22);
+    if (doPhotons_) idsToKeep.push_back(22);
 
-    // This is a bit nasty because it assumes that Central is the first variation, which is NOT guaranteed!
+    // This is a bit nasty because it assumes that Central is the first
+    // variation, which is NOT guaranteed!
     if (variation.first == Central) {
         bornLeptons.clear();
         dressedLeptons.clear();
@@ -170,9 +180,11 @@ void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation
             if (GenDressedLepton_hasTauAnc.At(i)) {
                 continue;
             }
-            dressedLeptons.emplace_back(makeGenParticle(GenDressedLepton_pdgId.At(i), 1, GenDressedLepton_pt.At(i), 
-                                        GenDressedLepton_eta.At(i), GenDressedLepton_phi.At(i), GenDressedLepton_mass.At(i)));
-        } // No need to sort, they're already pt sorted
+            dressedLeptons.emplace_back(makeGenParticle(
+                GenDressedLepton_pdgId.At(i), 1, GenDressedLepton_pt.At(i),
+                GenDressedLepton_eta.At(i), GenDressedLepton_phi.At(i),
+                GenDressedLepton_mass.At(i)));
+        }  // No need to sort, they're already pt sorted
         leptons = dressedLeptons;
         // Do once, only if bare or born leptons are requested
         if (doNeutrinos_ || doBorn_ || doBareLeptons_) {
@@ -181,24 +193,26 @@ void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation
                 bool isPrompt = (GenPart_statusFlags.At(i) >> 0) & 1;
                 if (!(isHardProcess || (GenPart_status.At(i) == 1 && isPrompt)))
                     continue;
-                if (std::find(idsToKeep.begin(), idsToKeep.end(), std::abs(GenPart_pdgId.At(i))) == idsToKeep.end())
+                if (std::find(idsToKeep.begin(), idsToKeep.end(),
+                              std::abs(GenPart_pdgId.At(i))) == idsToKeep.end())
                     continue;
 
-                auto part = makeGenParticle(GenPart_pdgId.At(i), GenPart_status.At(i), GenPart_pt.At(i), 
-                        GenPart_eta.At(i), GenPart_phi.At(i), GenPart_mass.At(i));
-                if (std::abs(part.pdgId()) == 11 || std::abs(part.pdgId()) == 13) {
+                auto part = makeGenParticle(
+                    GenPart_pdgId.At(i), GenPart_status.At(i), GenPart_pt.At(i),
+                    GenPart_eta.At(i), GenPart_phi.At(i), GenPart_mass.At(i));
+                if (std::abs(part.pdgId()) == 11 ||
+                    std::abs(part.pdgId()) == 13) {
                     if (doBareLeptons_ && isPrompt && GenPart_status.At(i) == 1)
                         bareLeptons.emplace_back(part);
                     if (isHardProcess && doBorn_)
                         bornLeptons.emplace_back(part);
-                }
-                else if (std::abs(part.pdgId()) == 12 || std::abs(part.pdgId()) == 14) {
+                } else if (std::abs(part.pdgId()) == 12 ||
+                           std::abs(part.pdgId()) == 14) {
                     if (GenPart_status.At(i) == 1)
                         fsneutrinos.emplace_back(part);
                     if (isHardProcess && doBorn_)
                         bornNeutrinos.emplace_back(part);
-                }
-                else if (std::abs(part.pdgId()) == 22 && isPrompt) {
+                } else if (std::abs(part.pdgId()) == 22 && isPrompt) {
                     photons.emplace_back(part);
                 }
             }
@@ -206,77 +220,78 @@ void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation
         // Warning! Only really works for the W
         if (bareLeptons.size() > 0 && doPhotons_) {
             auto& lep = bareLeptons.at(0);
-            photons.erase(std::remove_if(photons.begin(), photons.end(), 
-                    [lep] (const reco::GenParticle& p) { return reco::deltaR(p, lep) > 0.1; }),
-                photons.end()
-            );
+            photons.erase(std::remove_if(photons.begin(), photons.end(),
+                                         [lep](const reco::GenParticle& p) {
+                                             return reco::deltaR(p, lep) > 0.1;
+                                         }),
+                          photons.end());
         }
         neutrinos = fsneutrinos;
         std::sort(bareLeptons.begin(), bareLeptons.end(), compareMaxByPt);
         std::sort(bornLeptons.begin(), bornLeptons.end(), compareMaxByPt);
-    }
-    else if (variation.first == BareLeptons) {
+    } else if (variation.first == BareLeptons) {
         leptons = bareLeptons;
         neutrinos = fsneutrinos;
-    }
-    else if (variation.first == BornParticles) {
+    } else if (variation.first == BornParticles) {
         leptons = bornLeptons;
         neutrinos = bornNeutrinos;
-    }
-    else if (variation.first == LHEParticles) {
+    } else if (variation.first == LHEParticles) {
         lheLeptons.clear();
         lheNeutrinos.clear();
         for (size_t i = 0; i < *nLHEPart; i++) {
-            if (std::find(idsToKeep.begin(), idsToKeep.end(), std::abs(LHEPart_pdgId.At(i))) == idsToKeep.end())
+            if (std::find(idsToKeep.begin(), idsToKeep.end(),
+                          std::abs(LHEPart_pdgId.At(i))) == idsToKeep.end())
                 continue;
 
-            auto part = makeGenParticle(LHEPart_pdgId.At(i), 1, LHEPart_pt.At(i), 
-                    LHEPart_eta.At(i), LHEPart_phi.At(i), LHEPart_mass.At(i));
+            auto part = makeGenParticle(LHEPart_pdgId.At(i), 1,
+                                        LHEPart_pt.At(i), LHEPart_eta.At(i),
+                                        LHEPart_phi.At(i), LHEPart_mass.At(i));
 
             if (std::abs(part.pdgId()) == 11 || std::abs(part.pdgId()) == 13) {
                 lheLeptons.emplace_back(part);
-            }
-            else if (std::abs(part.pdgId()) == 12 || std::abs(part.pdgId()) == 14) {
+            } else if (std::abs(part.pdgId()) == 12 ||
+                       std::abs(part.pdgId()) == 14) {
                 lheNeutrinos.emplace_back(part);
             }
             // No dR check here, should add
-            else if ((std::abs(part.pdgId()) < 6 || std::abs(part.pdgId()) == 21) && part.pt() > 30) {
+            else if ((std::abs(part.pdgId()) < 6 ||
+                      std::abs(part.pdgId()) == 21) &&
+                     part.pt() > 30) {
                 jets.emplace_back(part.polarP4());
             }
         }
         std::sort(lheLeptons.begin(), lheLeptons.end(), compareMaxByPt);
         leptons = lheLeptons;
         neutrinos = lheNeutrinos;
-    }
-    else if (variation.first == ptV0to3_lhe ||
-            variation.first == ptV3to5_lhe || 
-            variation.first == ptV5to7_lhe ||
-            variation.first == ptV7to9_lhe ||
-            variation.first == ptV9to12_lhe ||
-            variation.first == ptV12to15_lhe || 
-            variation.first == ptV15to20_lhe ||
-            variation.first == ptV20to27_lhe ||
-            variation.first == ptV27to40_lhe ||
-            variation.first == ptV40toInf_lhe ) {
+    } else if (variation.first == ptV0to3_lhe ||
+               variation.first == ptV3to5_lhe ||
+               variation.first == ptV5to7_lhe ||
+               variation.first == ptV7to9_lhe ||
+               variation.first == ptV9to12_lhe ||
+               variation.first == ptV12to15_lhe ||
+               variation.first == ptV15to20_lhe ||
+               variation.first == ptV20to27_lhe ||
+               variation.first == ptV27to40_lhe ||
+               variation.first == ptV40toInf_lhe) {
         leptons = lheLeptons;
         neutrinos = lheNeutrinos;
-    }
-    else {
+    } else {
         leptons = dressedLeptons;
         neutrinos = fsneutrinos;
     }
-        
+
     if (variation.first != LHEParticles) {
         jets.clear();
         ht = 0;
         for (size_t i = 0; i < *nGenJet; i++) {
-            auto jet = makeGenParticle(0, 1, GenJet_pt.At(i), 
-                    GenJet_eta.At(i), GenJet_phi.At(i), GenJet_mass.At(i));
-            if (jet.pt() > 30 && !helpers::overlapsCollection(jet.polarP4(), leptons, 0.4, nLeptons_)) {
+            auto jet = makeGenParticle(0, 1, GenJet_pt.At(i), GenJet_eta.At(i),
+                                       GenJet_phi.At(i), GenJet_mass.At(i));
+            if (jet.pt() > 30 && !helpers::overlapsCollection(
+                                     jet.polarP4(), leptons, 0.4, nLeptons_)) {
                 ht += jet.pt();
                 jets.emplace_back(jet.polarP4());
             }
-        } // No need to sort jets, they're already pt sorted
+        }  // No need to sort jets, they're already pt sorted
 
         genMet.SetPt(*MET_fiducialGenPt);
         genMet.SetPhi(*MET_fiducialGenPhi);
@@ -284,57 +299,60 @@ void NanoGenSelectorBase::LoadBranchesNanoAOD(Long64_t entry, SystPair variation
         genMet.SetEta(0.);
     }
 
-    weight = *genWeight;       
-    if (weightSignOnly_)
-        weight /= std::abs(*genWeight);
+    weight = *genWeight;
+    if (weightSignOnly_) weight /= std::abs(*genWeight);
     // The don't really work together
     else if (weightSuppress_ && std::abs(*genWeight) > weightSuppress_) {
         weight = 0;
         *genWeight = 0;
     }
 
-    if (refWeight == 1)
-        refWeight = weight;
+    if (refWeight == 1) refWeight = weight;
 
     if (centralWeightIndex_ != -1) {
         weight *= LHEScaleWeight.At(centralWeightIndex_);
     }
-    if (doMC2H_)
-        buildHessian2MCSet();
+    if (doMC2H_) buildHessian2MCSet();
 
     SetComposite();
 }
 
-reco::GenParticle NanoGenSelectorBase::makeGenParticle(int pdgid, int status, float pt, float eta, float phi, float m) {
+reco::GenParticle NanoGenSelectorBase::makeGenParticle(int pdgid, int status,
+                                                       float pt, float eta,
+                                                       float phi, float m) {
     LorentzVector vec;
     vec.SetPt(pt);
     vec.SetEta(eta);
     vec.SetPhi(phi);
     vec.SetM(m);
-    int charge = (pdgid < 0) ? 1: -1;
-    if (std::abs(pdgid) ==  12 || std::abs(pdgid) ==  14 || std::abs(pdgid) ==  16 || std::abs(pdgid) ==  22 || std::abs(pdgid) ==  23)
+    int charge = (pdgid < 0) ? 1 : -1;
+    if (std::abs(pdgid) == 12 || std::abs(pdgid) == 14 ||
+        std::abs(pdgid) == 16 || std::abs(pdgid) == 22 || std::abs(pdgid) == 23)
         charge = 0;
-    
-    auto lep = reco::GenParticle(charge, vec, reco::Particle::Point(), pdgid, status, true);
+
+    auto lep = reco::GenParticle(charge, vec, reco::Particle::Point(), pdgid,
+                                 status, true);
     return lep;
 }
 
 void NanoGenSelectorBase::buildHessian2MCSet() {
     double pdfWeights[N_LHEPDF_WEIGHTS_];
-//    for (size_t i = 0; i < N_LHEPDF_WEIGHTS_; i++) {
-//        pdfWeights[i] = LHEPdfWeight[i];
-//    }
-    pdfweightshelper_.DoMC2Hessian(1., const_cast<const double*>(pdfWeights), LHEHessianPdfWeight);
+    //    for (size_t i = 0; i < N_LHEPDF_WEIGHTS_; i++) {
+    //        pdfWeights[i] = LHEPdfWeight[i];
+    //    }
+    pdfweightshelper_.DoMC2Hessian(1., const_cast<const double*>(pdfWeights),
+                                   LHEHessianPdfWeight);
 }
 
 double NanoGenSelectorBase::breitWignerWeight(double offset) {
-
     double targetMass = MV_GEN_ + offset;
-    double s_hat = mVlhe*mVlhe;
-    double offshell = s_hat - MV_GEN_*MV_GEN_;
-    double offshellOffset = s_hat - targetMass*targetMass;
-    double weight = (offshell*offshell + GAMMAV_GEN_*GAMMAV_GEN_*MV_GEN_*MV_GEN_)/
-            (offshellOffset*offshellOffset + GAMMAV_GEN_*GAMMAV_GEN_*targetMass*targetMass);
+    double s_hat = mVlhe * mVlhe;
+    double offshell = s_hat - MV_GEN_ * MV_GEN_;
+    double offshellOffset = s_hat - targetMass * targetMass;
+    double weight =
+        (offshell * offshell + GAMMAV_GEN_ * GAMMAV_GEN_ * MV_GEN_ * MV_GEN_) /
+        (offshellOffset * offshellOffset +
+         GAMMAV_GEN_ * GAMMAV_GEN_ * targetMass * targetMass);
     return weight;
 }
 
@@ -342,7 +360,8 @@ void NanoGenSelectorBase::SetupNewDirectory() {
     SelectorBase::SetupNewDirectory();
     AddObject<TH1D>(mcWeights_, "genWeights", "gen weights", 200, -10, 10);
     AddObject<TH1D>(mcPdfWeights_, "MCPdfweights", "MC pdf weights", 200, 0, 2);
-    AddObject<TH1D>(hesPdfWeights_, "Hesweights", "Hessian pdf weights", 200, 0, 2);
+    AddObject<TH1D>(hesPdfWeights_, "Hesweights", "Hessian pdf weights", 200, 0,
+                    2);
     AddObject<TH1D>(scaleWeights_, "scaleweights", "Scale weights", 200, 0, 2);
 
     InitializeHistogramsFromConfig();

--- a/src/ScaleFactor.cc
+++ b/src/ScaleFactor.cc
@@ -1,193 +1,192 @@
 /* Scale Factor class for applying scale factors in ROOT hists etc.
  *
  * By N. Smith, U. Wisconsin
- * 
+ *
  */
 #include "Analysis/VVAnalysis/interface/ScaleFactor.h"
 #include "TInterpreter.h"
 
-ScaleFactor::~ScaleFactor()
-{
-  SafeDelete(histCentral1D_);
-  SafeDelete(histShiftUp1D_);
-  SafeDelete(histShiftDown1D_);
-  SafeDelete(histCentral2D_);
-  SafeDelete(histShiftUp2D_);
-  SafeDelete(histShiftDown2D_);
+ScaleFactor::~ScaleFactor() {
+    SafeDelete(histCentral1D_);
+    SafeDelete(histShiftUp1D_);
+    SafeDelete(histShiftDown1D_);
+    SafeDelete(histCentral2D_);
+    SafeDelete(histShiftUp2D_);
+    SafeDelete(histShiftDown2D_);
 }
 
-void ScaleFactor::Set1DHist(TH1D * central, TH1D * shiftUp, TH1D * shiftDown, OverflowBehavior b)
-{
-  histCentral1D_ = (TH1D *) central->Clone("Central1D");
-  histCentral1D_->SetDirectory(0);
-  SetOverflowBins(histCentral1D_, b);
-  if ( shiftUp != nullptr ) {
-    histShiftUp1D_ = (TH1D *) shiftUp->Clone("Up1D");
-    histShiftUp1D_->SetDirectory(0);
-    SetOverflowBins(histShiftUp1D_, b);
-  }
-  if ( shiftDown != nullptr ) {
-    histShiftDown1D_ = (TH1D *) shiftDown->Clone("Down1D");
-    histShiftDown1D_->SetDirectory(0);
-    SetOverflowBins(histShiftDown1D_, b);
-  }
-}
-
-TH1D * ScaleFactor::Get1DHist(Variation var)
-{
-  switch (var) {
-    case CentralValue:
-      return histCentral1D_;
-    case ShiftUp:
-      return histShiftUp1D_;
-    case ShiftDown:
-      return histShiftDown1D_;
-  }
-  return nullptr;
-}
-
-void ScaleFactor::Set2DHist(TH2D * central, TH2D * shiftUp, TH2D * shiftDown, OverflowBehavior b)
-{
-  histCentral2D_ = (TH2D *) central->Clone("Central2D");
-  histCentral2D_->SetDirectory(0);
-  SetOverflowBins(histCentral2D_, b);
-  if ( shiftUp != nullptr ) {
-    histShiftUp2D_ = (TH2D *) shiftUp->Clone("Up2D");
-    histShiftUp2D_->SetDirectory(0);
-    SetOverflowBins(histShiftUp2D_, b);
-  }
-  if ( shiftDown != nullptr ) {
-    histShiftDown2D_ = (TH2D *) shiftDown->Clone("Down2D");
-    histShiftDown2D_->SetDirectory(0);
-    SetOverflowBins(histShiftDown2D_, b);
-  }
-}
-
-TH2D * ScaleFactor::Get2DHist(Variation var)
-{
-  switch (var) {
-    case CentralValue:
-      return histCentral2D_;
-    case ShiftUp:
-      return histShiftUp2D_;
-    case ShiftDown:
-      return histShiftDown2D_;
-  }
-  return nullptr;
-}
-
-double ScaleFactor::Evaluate1D(double x, Variation var) const
-{
-  if ( var == CentralValue && histCentral1D_ != nullptr ) {
-    auto bin = histCentral1D_->FindBin(x);
-    return histCentral1D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftUp && histShiftUp1D_ != nullptr ) {
-    auto bin = histShiftUp1D_->FindBin(x);
-    return histShiftUp1D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftUp && histCentral1D_ != nullptr ) {
-    auto bin = histCentral1D_->FindBin(x);
-    return histCentral1D_->GetBinContent(bin) + histCentral1D_->GetBinError(bin);
-  }
-  else if ( var == ShiftDown && histShiftDown1D_ != nullptr ) {
-    auto bin = histShiftDown1D_->FindBin(x);
-    return histShiftDown1D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftDown && histCentral1D_ != nullptr ) {
-    auto bin = histCentral1D_->FindBin(x);
-    return histCentral1D_->GetBinContent(bin) - histCentral1D_->GetBinError(bin);
-  }
-  // If here, we probably forgot to add the hist
-  return 1.;
-}
-
-double ScaleFactor::Evaluate2D(double x, double y, Variation var) const
-{
-  if ( var == CentralValue && histCentral2D_ != nullptr ) {
-    auto bin = histCentral2D_->FindBin(x, y);
-    return histCentral2D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftUp && histShiftUp2D_ != nullptr ) {
-    auto bin = histShiftUp2D_->FindBin(x, y);
-    return histShiftUp2D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftUp && histCentral2D_ != nullptr ) {
-    auto bin = histCentral2D_->FindBin(x, y);
-    return histCentral2D_->GetBinContent(bin) + histCentral2D_->GetBinError(bin);
-  }
-  else if ( var == ShiftDown && histShiftDown2D_ != nullptr ) {
-    auto bin = histShiftDown2D_->FindBin(x, y);
-    return histShiftDown2D_->GetBinContent(bin);
-  }
-  else if ( var == ShiftDown && histCentral2D_ != nullptr ) {
-    auto bin = histCentral2D_->FindBin(x, y);
-    return histCentral2D_->GetBinContent(bin) - histCentral2D_->GetBinError(bin);
-  }
-  // If here, we probably forgot to add the hist
-  return 1.;
-}
-
-void ScaleFactor::RegisterGlobalFunction(int dimension)
-{
-  TObject * prev = gROOT->GetListOfSpecials()->FindObject(GetName());
-  if ( prev != nullptr && prev != (TObject *) this ) {
-    Error("ScaleFactor", "RegisterGlobalFunction(): There is an object with this name already in global specials");
-    return;
-  }
-  else if ( prev == nullptr ) {
-    gROOT->GetListOfSpecials()->Add(this);
-  }
-
-  auto interpreter = gROOT->GetInterpreter();
-  if ( interpreter == nullptr ) {
-    Error("ScaleFactor", "RegisterGlobalFunction() only works in interactive ROOT context");
-  }
-
-  if ( dimension == 1 ) {
-    TString fDecl(Form("double %s(double x) { auto ptr = (ScaleFactor*) gROOT->GetListOfSpecials()->FindObject(\"%s\"); return ptr->Evaluate1D(x); }", GetName(), GetName()));
-    interpreter->Declare(fDecl);
-  }
-  else if ( dimension == 2 ) {
-    TString fDecl(Form("double %s(double x, double y) { auto ptr = (ScaleFactor*) gROOT->GetListOfSpecials()->FindObject(\"%s\"); return ptr->Evaluate2D(x, y); }", GetName(), GetName()));
-    interpreter->Declare(fDecl);
-  }
-  else {
-    Error("ScaleFactor", "Called RegisterGlobalFunction() with unsupported dimension (%d)", dimension);
-  }
-}
-
-void ScaleFactor::SetOverflowBins(TH1D * hist, OverflowBehavior b)
-{
-  if ( b == AsInHist ) return;
-  else if ( b == NearestEntry ) {
-    hist->SetBinContent(0, hist->GetBinContent(1));
-    hist->SetBinError(0, hist->GetBinError(1));
-    auto lastBin = hist->GetNbinsX();
-    hist->SetBinContent(lastBin+1, hist->GetBinContent(lastBin));
-    hist->SetBinError(lastBin+1, hist->GetBinError(lastBin));
-  }
-  else if ( b == Unity ) {
-    hist->SetBinContent(0, 1.);
-    hist->SetBinError(0, 0.);
-    auto lastBin = hist->GetNbinsX();
-    hist->SetBinContent(lastBin+1, 1.);
-    hist->SetBinError(lastBin+1, 0.);
-  }
-}
-
-void ScaleFactor::SetOverflowBins(TH2D * hist, OverflowBehavior b)
-{
-  if ( b == AsInHist ) return;
-  else if ( b == NearestEntry ) {
-    // TODO: a fair bit of work
-  }
-  else if ( b == Unity ) {
-    for(int bin=0; bin<hist->GetNcells(); ++bin) {
-      if ( hist->IsBinUnderflow(bin) || hist->IsBinOverflow(bin) ) {
-        hist->SetBinContent(bin, 1.);
-        hist->SetBinError(bin, 0.);
-      }
+void ScaleFactor::Set1DHist(TH1D *central, TH1D *shiftUp, TH1D *shiftDown,
+                            OverflowBehavior b) {
+    histCentral1D_ = (TH1D *)central->Clone("Central1D");
+    histCentral1D_->SetDirectory(0);
+    SetOverflowBins(histCentral1D_, b);
+    if (shiftUp != nullptr) {
+        histShiftUp1D_ = (TH1D *)shiftUp->Clone("Up1D");
+        histShiftUp1D_->SetDirectory(0);
+        SetOverflowBins(histShiftUp1D_, b);
     }
-  }
+    if (shiftDown != nullptr) {
+        histShiftDown1D_ = (TH1D *)shiftDown->Clone("Down1D");
+        histShiftDown1D_->SetDirectory(0);
+        SetOverflowBins(histShiftDown1D_, b);
+    }
+}
+
+TH1D *ScaleFactor::Get1DHist(Variation var) {
+    switch (var) {
+        case CentralValue:
+            return histCentral1D_;
+        case ShiftUp:
+            return histShiftUp1D_;
+        case ShiftDown:
+            return histShiftDown1D_;
+    }
+    return nullptr;
+}
+
+void ScaleFactor::Set2DHist(TH2D *central, TH2D *shiftUp, TH2D *shiftDown,
+                            OverflowBehavior b) {
+    histCentral2D_ = (TH2D *)central->Clone("Central2D");
+    histCentral2D_->SetDirectory(0);
+    SetOverflowBins(histCentral2D_, b);
+    if (shiftUp != nullptr) {
+        histShiftUp2D_ = (TH2D *)shiftUp->Clone("Up2D");
+        histShiftUp2D_->SetDirectory(0);
+        SetOverflowBins(histShiftUp2D_, b);
+    }
+    if (shiftDown != nullptr) {
+        histShiftDown2D_ = (TH2D *)shiftDown->Clone("Down2D");
+        histShiftDown2D_->SetDirectory(0);
+        SetOverflowBins(histShiftDown2D_, b);
+    }
+}
+
+TH2D *ScaleFactor::Get2DHist(Variation var) {
+    switch (var) {
+        case CentralValue:
+            return histCentral2D_;
+        case ShiftUp:
+            return histShiftUp2D_;
+        case ShiftDown:
+            return histShiftDown2D_;
+    }
+    return nullptr;
+}
+
+double ScaleFactor::Evaluate1D(double x, Variation var) const {
+    if (var == CentralValue && histCentral1D_ != nullptr) {
+        auto bin = histCentral1D_->FindBin(x);
+        return histCentral1D_->GetBinContent(bin);
+    } else if (var == ShiftUp && histShiftUp1D_ != nullptr) {
+        auto bin = histShiftUp1D_->FindBin(x);
+        return histShiftUp1D_->GetBinContent(bin);
+    } else if (var == ShiftUp && histCentral1D_ != nullptr) {
+        auto bin = histCentral1D_->FindBin(x);
+        return histCentral1D_->GetBinContent(bin) +
+               histCentral1D_->GetBinError(bin);
+    } else if (var == ShiftDown && histShiftDown1D_ != nullptr) {
+        auto bin = histShiftDown1D_->FindBin(x);
+        return histShiftDown1D_->GetBinContent(bin);
+    } else if (var == ShiftDown && histCentral1D_ != nullptr) {
+        auto bin = histCentral1D_->FindBin(x);
+        return histCentral1D_->GetBinContent(bin) -
+               histCentral1D_->GetBinError(bin);
+    }
+    // If here, we probably forgot to add the hist
+    return 1.;
+}
+
+double ScaleFactor::Evaluate2D(double x, double y, Variation var) const {
+    if (var == CentralValue && histCentral2D_ != nullptr) {
+        auto bin = histCentral2D_->FindBin(x, y);
+        return histCentral2D_->GetBinContent(bin);
+    } else if (var == ShiftUp && histShiftUp2D_ != nullptr) {
+        auto bin = histShiftUp2D_->FindBin(x, y);
+        return histShiftUp2D_->GetBinContent(bin);
+    } else if (var == ShiftUp && histCentral2D_ != nullptr) {
+        auto bin = histCentral2D_->FindBin(x, y);
+        return histCentral2D_->GetBinContent(bin) +
+               histCentral2D_->GetBinError(bin);
+    } else if (var == ShiftDown && histShiftDown2D_ != nullptr) {
+        auto bin = histShiftDown2D_->FindBin(x, y);
+        return histShiftDown2D_->GetBinContent(bin);
+    } else if (var == ShiftDown && histCentral2D_ != nullptr) {
+        auto bin = histCentral2D_->FindBin(x, y);
+        return histCentral2D_->GetBinContent(bin) -
+               histCentral2D_->GetBinError(bin);
+    }
+    // If here, we probably forgot to add the hist
+    return 1.;
+}
+
+void ScaleFactor::RegisterGlobalFunction(int dimension) {
+    TObject *prev = gROOT->GetListOfSpecials()->FindObject(GetName());
+    if (prev != nullptr && prev != (TObject *)this) {
+        Error("ScaleFactor",
+              "RegisterGlobalFunction(): There is an object with this name "
+              "already in global specials");
+        return;
+    } else if (prev == nullptr) {
+        gROOT->GetListOfSpecials()->Add(this);
+    }
+
+    auto interpreter = gROOT->GetInterpreter();
+    if (interpreter == nullptr) {
+        Error(
+            "ScaleFactor",
+            "RegisterGlobalFunction() only works in interactive ROOT context");
+    }
+
+    if (dimension == 1) {
+        TString fDecl(
+            Form("double %s(double x) { auto ptr = (ScaleFactor*) "
+                 "gROOT->GetListOfSpecials()->FindObject(\"%s\"); return "
+                 "ptr->Evaluate1D(x); }",
+                 GetName(), GetName()));
+        interpreter->Declare(fDecl);
+    } else if (dimension == 2) {
+        TString fDecl(
+            Form("double %s(double x, double y) { auto ptr = (ScaleFactor*) "
+                 "gROOT->GetListOfSpecials()->FindObject(\"%s\"); return "
+                 "ptr->Evaluate2D(x, y); }",
+                 GetName(), GetName()));
+        interpreter->Declare(fDecl);
+    } else {
+        Error("ScaleFactor",
+              "Called RegisterGlobalFunction() with unsupported dimension (%d)",
+              dimension);
+    }
+}
+
+void ScaleFactor::SetOverflowBins(TH1D *hist, OverflowBehavior b) {
+    if (b == AsInHist)
+        return;
+    else if (b == NearestEntry) {
+        hist->SetBinContent(0, hist->GetBinContent(1));
+        hist->SetBinError(0, hist->GetBinError(1));
+        auto lastBin = hist->GetNbinsX();
+        hist->SetBinContent(lastBin + 1, hist->GetBinContent(lastBin));
+        hist->SetBinError(lastBin + 1, hist->GetBinError(lastBin));
+    } else if (b == Unity) {
+        hist->SetBinContent(0, 1.);
+        hist->SetBinError(0, 0.);
+        auto lastBin = hist->GetNbinsX();
+        hist->SetBinContent(lastBin + 1, 1.);
+        hist->SetBinError(lastBin + 1, 0.);
+    }
+}
+
+void ScaleFactor::SetOverflowBins(TH2D *hist, OverflowBehavior b) {
+    if (b == AsInHist)
+        return;
+    else if (b == NearestEntry) {
+        // TODO: a fair bit of work
+    } else if (b == Unity) {
+        for (int bin = 0; bin < hist->GetNcells(); ++bin) {
+            if (hist->IsBinUnderflow(bin) || hist->IsBinOverflow(bin)) {
+                hist->SetBinContent(bin, 1.);
+                hist->SetBinError(bin, 0.);
+            }
+        }
+    }
 }

--- a/src/SelectorBase.cc
+++ b/src/SelectorBase.cc
@@ -1,86 +1,80 @@
 #include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include <boost/algorithm/string.hpp>
 #include <TStyle.h>
+#include <boost/algorithm/string.hpp>
 #include <regex>
 #include "TParameter.h"
 
-void SelectorBase::Begin(TTree * /*tree*/)
-{
-    TString option = GetOption();
-}
+void SelectorBase::Begin(TTree* /*tree*/) { TString option = GetOption(); }
 
-void SelectorBase::SlaveBegin(TTree * /*tree*/)
-{
+void SelectorBase::SlaveBegin(TTree* /*tree*/) {
     if (GetInputList() != nullptr) {
-        TParameter<bool>* applyScaleFactors = (TParameter<bool>*) GetInputList()->FindObject("applyScaleFacs");
+        TParameter<bool>* applyScaleFactors =
+            (TParameter<bool>*)GetInputList()->FindObject("applyScaleFacs");
         if (applyScaleFactors != nullptr && applyScaleFactors->GetVal()) {
-           SetScaleFactors();
+            SetScaleFactors();
         }
     }
 }
 
-void SelectorBase::Init(TTree *tree)
-{
+void SelectorBase::Init(TTree* tree) {
     if (!tree) return;
     fChain = tree;
-    
+
     TString option = GetOption();
 
     if (GetInputList() != nullptr) {
-	TNamed* ntupleType = (TNamed *) GetInputList()->FindObject("ntupleType");
-    TNamed* name = (TNamed *) GetInputList()->FindObject("name");
-    TNamed* chan = (TNamed *) GetInputList()->FindObject("channel");
-    TNamed* selection = (TNamed *) GetInputList()->FindObject("selection");
-	TNamed* year = (TNamed *) GetInputList()->FindObject("year");
+        TNamed* ntupleType = (TNamed*)GetInputList()->FindObject("ntupleType");
+        TNamed* name = (TNamed*)GetInputList()->FindObject("name");
+        TNamed* chan = (TNamed*)GetInputList()->FindObject("channel");
+        TNamed* selection = (TNamed*)GetInputList()->FindObject("selection");
+        TNamed* year = (TNamed*)GetInputList()->FindObject("year");
 
-	if (ntupleType != nullptr) {
-	    std::string ntupleName = ntupleType->GetTitle();
-	    if (ntupleName == "NanoAOD")
-		    ntupleType_ = NanoAOD;
-	    else if (ntupleName  == "UWVV")
-		ntupleType_ = UWVV;
-	    else if (ntupleName  == "Bacon")
-		ntupleType_ = Bacon;
-	    else
-		    throw std::invalid_argument("Unsupported ntuple type!");
-	}
-	else {
-	    std::cerr << "INFO: Assuming NanoAOD ntuples" << std::endl;
-	    ntupleType_ = NanoAOD;
-	}
+        if (ntupleType != nullptr) {
+            std::string ntupleName = ntupleType->GetTitle();
+            if (ntupleName == "NanoAOD")
+                ntupleType_ = NanoAOD;
+            else if (ntupleName == "UWVV")
+                ntupleType_ = UWVV;
+            else if (ntupleName == "Bacon")
+                ntupleType_ = Bacon;
+            else
+                throw std::invalid_argument("Unsupported ntuple type!");
+        } else {
+            std::cerr << "INFO: Assuming NanoAOD ntuples" << std::endl;
+            ntupleType_ = NanoAOD;
+        }
 
         if (name != nullptr) {
             name_ = name->GetTitle();
-        }
-        else {
+        } else {
             name_ = GetNameFromFile();
         }
-        if (name_.empty()){
-            std::cerr << "INFO: Using default name \"Unknown\" for file" << std::endl;
+        if (name_.empty()) {
+            std::cerr << "INFO: Using default name \"Unknown\" for file"
+                      << std::endl;
             name_ = "Unknown";
         }
-	if(year != nullptr) {
-	    year_ = yearMap_[year->GetTitle()];
-	}
-	
-	if (chan != nullptr) {
-	    channelName_ = chan->GetTitle();
-	}
-	else if (ntupleType_ == UWVV)
+        if (year != nullptr) {
+            year_ = yearMap_[year->GetTitle()];
+        }
+
+        if (chan != nullptr) {
+            channelName_ = chan->GetTitle();
+        } else if (ntupleType_ == UWVV)
             channelName_ = fChain->GetTree()->GetDirectory()->GetName();
         if (selection != nullptr) {
             selectionName_ = selection->GetTitle();
         }
     }
-    
+
     if (selectionMap_.find(selectionName_) != selectionMap_.end()) {
-	    selection_ = selectionMap_[selectionName_];
-    }
-    else
-        throw std::invalid_argument(selectionName_ + " is not a valid selection!");
-    
+        selection_ = selectionMap_[selectionName_];
+    } else
+        throw std::invalid_argument(selectionName_ +
+                                    " is not a valid selection!");
+
     isMC_ = false;
-    if (name_.find("data") == std::string::npos){
+    if (name_.find("data") == std::string::npos) {
         isMC_ = true;
     }
     if (doSystematics_ && isMC_ && !isNonprompt_)
@@ -92,15 +86,14 @@ void SelectorBase::Init(TTree *tree)
         std::string message = "Invalid channel choice! ";
         message += "Choice was " + channelName_ + "\n";
         message += "Valid choices are: ";
-        for (const auto& chan : channelMap_)
-            message += chan.first + ", " ;
+        for (const auto& chan : channelMap_) message += chan.first + ", ";
         throw std::invalid_argument(message);
     }
 
     // only make the directory iff class isn't being run as a slave class /////
-    TNamed* isSlaveClass = (TNamed *) GetInputList()->FindObject("isSlaveClass");
-    if(isSlaveClass != nullptr) return;
-    
+    TNamed* isSlaveClass = (TNamed*)GetInputList()->FindObject("isSlaveClass");
+    if (isSlaveClass != nullptr) return;
+
     makeOutputDirs();
     SetBranches();
 }
@@ -110,38 +103,44 @@ void SelectorBase::addSubprocesses(std::vector<std::string> processes) {
 }
 
 void SelectorBase::setSubprocesses(std::string process) {
-    currentHistDir_ = dynamic_cast<TList*>(fOutput->FindObject(process.c_str()));
+    currentHistDir_ =
+        dynamic_cast<TList*>(fOutput->FindObject(process.c_str()));
     if (currentHistDir_ == nullptr) {
         currentHistDir_ = new TList();
         currentHistDir_->SetName(process.c_str());
-        std::cout << "Info: Setting output dir name to " << process << std::endl;
+        std::cout << "Info: Setting output dir name to " << process
+                  << std::endl;
         fOutput->Add(currentHistDir_);
     }
-        //throw std::invalid_argument(process + " is not a valid subprocess for selector!");
+    // throw std::invalid_argument(process + " is not a valid subprocess for
+    // selector!");
 }
 
 void SelectorBase::makeOutputDirs() {
     std::vector<std::string> allProcesses = {name_};
-    allProcesses.insert(allProcesses.begin(), subprocesses_.begin(), subprocesses_.end());
-    
-    for (auto& name : allProcesses) { 
-        currentHistDir_ = dynamic_cast<TList*>(fOutput->FindObject(name.c_str()));
-        
-        if ( currentHistDir_ == nullptr ) {
+    allProcesses.insert(allProcesses.begin(), subprocesses_.begin(),
+                        subprocesses_.end());
+
+    for (auto& name : allProcesses) {
+        currentHistDir_ =
+            dynamic_cast<TList*>(fOutput->FindObject(name.c_str()));
+
+        if (currentHistDir_ == nullptr) {
             currentHistDir_ = new TList();
             currentHistDir_->SetName(name.c_str());
             fOutput->Add(currentHistDir_);
-            if (name == name_)
-                SetupNewDirectory();
+            if (name == name_) SetupNewDirectory();
         }
     }
-    //TODO: Determine why this fails and if it's really needed
-    //size_t existingObjectPtrsSize = allObjects_.size();
+    // TODO: Determine why this fails and if it's really needed
+    // size_t existingObjectPtrsSize = allObjects_.size();
     // Watch for something that I hope never happens,
-    //if ( existingObjectPtrsSize > 0 && allObjects_.size() != existingObjectPtrsSize ) {
-    //    throw std::invalid_argument(Form("SelectorBase: Size of allObjects has changed!: %lu to %lu", existingObjectPtrsSize, allObjects_.size()));
+    // if ( existingObjectPtrsSize > 0 && allObjects_.size() !=
+    // existingObjectPtrsSize ) {
+    //    throw std::invalid_argument(Form("SelectorBase: Size of allObjects has
+    //    changed!: %lu to %lu", existingObjectPtrsSize, allObjects_.size()));
     //}
-    //UpdateDirectory();
+    // UpdateDirectory();
 }
 
 void SelectorBase::SetScaleFactors() {
@@ -155,9 +154,8 @@ void SelectorBase::SetBranches() {
         SetBranchesNanoAOD();
     else if (ntupleType_ == Bacon)
         SetBranchesBacon();
-    else 
+    else
         throw std::invalid_argument("Undefined ntuple type!");
-        
 }
 
 void SelectorBase::LoadBranches(Long64_t entry, SystPair variation) {
@@ -170,8 +168,7 @@ void SelectorBase::LoadBranches(Long64_t entry, SystPair variation) {
     }
 }
 
-Bool_t SelectorBase::Process(Long64_t entry)
-{
+Bool_t SelectorBase::Process(Long64_t entry) {
     for (const auto& variation : variations_) {
         LoadBranches(entry, variation);
         FillHistograms(entry, variation);
@@ -179,46 +176,47 @@ Bool_t SelectorBase::Process(Long64_t entry)
     return kTRUE;
 }
 
-Bool_t SelectorBase::Notify()
-{
-    return kTRUE;
-}
+Bool_t SelectorBase::Notify() { return kTRUE; }
 
-float SelectorBase::GetPrefiringEfficiencyWeight(
-        std::vector<float>* jetPt, std::vector<float>* jetEta) {
+float SelectorBase::GetPrefiringEfficiencyWeight(std::vector<float>* jetPt,
+                                                 std::vector<float>* jetEta) {
     float prefire_weight = 1;
     for (size_t i = 0; i < jetPt->size(); i++) {
         float jPt = jetPt->at(i);
         float jEta = std::abs(jetEta->at(i));
-        prefire_weight *= (1-prefireEff_->GetEfficiency(prefireEff_->FindFixBin(jEta, jPt)));
+        prefire_weight *= (1 - prefireEff_->GetEfficiency(
+                                   prefireEff_->FindFixBin(jEta, jPt)));
     }
     return prefire_weight;
 }
 
-void SelectorBase::Terminate()
-{
-}
-    
-void SelectorBase::SlaveTerminate()
-{
-}
-void SelectorBase::UpdateDirectory()
-{
-  for(TNamed** objPtrPtr : allObjects_) {
-    if ( *objPtrPtr == nullptr ) std::invalid_argument("SelectorBase: Call to UpdateObject but existing pointer is null");
-    *objPtrPtr = (TNamed *) currentHistDir_->FindObject((*objPtrPtr)->GetName());
-    if ( *objPtrPtr == nullptr ) std::invalid_argument("SelectorBase: Call to UpdateObject but current directory has no instance");
-  }
+void SelectorBase::Terminate() {}
+
+void SelectorBase::SlaveTerminate() {}
+void SelectorBase::UpdateDirectory() {
+    for (TNamed** objPtrPtr : allObjects_) {
+        if (*objPtrPtr == nullptr)
+            std::invalid_argument(
+                "SelectorBase: Call to UpdateObject but existing pointer is "
+                "null");
+        *objPtrPtr =
+            (TNamed*)currentHistDir_->FindObject((*objPtrPtr)->GetName());
+        if (*objPtrPtr == nullptr)
+            std::invalid_argument(
+                "SelectorBase: Call to UpdateObject but current directory has "
+                "no instance");
+    }
 }
 
-template<typename T>
-void SelectorBase::InitializeHistMap(std::vector<std::string>& labels, std::unordered_map<HistLabel, T*>& histMap) {
+template <typename T>
+void SelectorBase::InitializeHistMap(
+    std::vector<std::string>& labels,
+    std::unordered_map<HistLabel, T*>& histMap) {
     for (auto& label : labels) {
         if (channel_ != Inclusive) {
             HistLabel histlabel = {label, channel_, Central};
             histMap[histlabel] = {};
-        }
-        else {
+        } else {
             for (auto& chan : allChannels_) {
                 HistLabel histlabel = {label, chan.first, Central};
                 histMap[histlabel] = {};
@@ -228,12 +226,14 @@ void SelectorBase::InitializeHistMap(std::vector<std::string>& labels, std::unor
 }
 
 void SelectorBase::InitializeHistogramsFromConfig() {
-    TList* histInfo = (TList *) GetInputList()->FindObject("histinfo");
-    if (histInfo == nullptr ) 
-        throw std::domain_error("Can't initialize histograms without passing histogram information to TSelector");
+    TList* histInfo = (TList*)GetInputList()->FindObject("histinfo");
+    if (histInfo == nullptr)
+        throw std::domain_error(
+            "Can't initialize histograms without passing histogram information "
+            "to TSelector");
 
-    InitializeHistMap(hists1D_,histMap1D_);
-    InitializeHistMap(hists2D_,histMap2D_);
+    InitializeHistMap(hists1D_, histMap1D_);
+    InitializeHistMap(hists2D_, histMap2D_);
     InitializeHistMap(weighthists1D_, weighthistMap1D_);
     InitializeHistMap(weighthists2D_, weighthistMap2D_);
 
@@ -247,11 +247,12 @@ void SelectorBase::InitializeHistogramsFromConfig() {
         }
     }
 
-    for (auto && entry : *histInfo) {  
+    for (auto&& entry : *histInfo) {
         TNamed* currentHistInfo = dynamic_cast<TNamed*>(entry);
         const char* name = currentHistInfo->GetName();
-        std::vector<std::string> histData = ReadHistDataFromConfig(currentHistInfo->GetTitle());
-        
+        std::vector<std::string> histData =
+            ReadHistDataFromConfig(currentHistInfo->GetTitle());
+
         std::vector<ChannelPair> channels = {{channel_, channelName_}};
         if (channel_ == Inclusive) {
             channels = allChannels_;
@@ -259,12 +260,17 @@ void SelectorBase::InitializeHistogramsFromConfig() {
 
         for (const auto& chan : channels) {
             HistLabel centralLabel = {name, chan.first, Central};
-            if (histMap1D_.find(centralLabel) != histMap1D_.end() || histMap2D_.find(centralLabel) != histMap2D_.end()) { 
+            if (histMap1D_.find(centralLabel) != histMap1D_.end() ||
+                histMap2D_.find(centralLabel) != histMap2D_.end()) {
                 InitializeHistogramFromConfig(name, chan, histData);
             }
-            // May add a syst hist to plotobjects for plotting purposes, surpress errors in this case
-            else if (std::find(tempSystHistNames.begin(), tempSystHistNames.end(), name) == tempSystHistNames.end())
-                std::cerr << "Skipping invalid histogram '" << name << "'" << std::endl;
+            // May add a syst hist to plotobjects for plotting purposes,
+            // surpress errors in this case
+            else if (std::find(tempSystHistNames.begin(),
+                               tempSystHistNames.end(),
+                               name) == tempSystHistNames.end())
+                std::cerr << "Skipping invalid histogram '" << name << "'"
+                          << std::endl;
         }
     }
 
@@ -274,129 +280,143 @@ void SelectorBase::InitializeHistogramsFromConfig() {
         subprocessMap = {};
         for (auto& hist : histMap1D_) {
             subprocessMap[hist.first] = {};
-            if (hist.second == nullptr)
-                continue;
-            AddObject<TH1D>(subprocessMap[hist.first], const_cast<TH1D&>(*hist.second));
-            //subprocessWeightHistMaps1D_[subporcess] = weighthistMap1D_;
+            if (hist.second == nullptr) continue;
+            AddObject<TH1D>(subprocessMap[hist.first],
+                            const_cast<TH1D&>(*hist.second));
+            // subprocessWeightHistMaps1D_[subporcess] = weighthistMap1D_;
         }
     }
 
     currentHistDir_ = dynamic_cast<TList*>(fOutput->FindObject(name_.c_str()));
 }
 
-void SelectorBase::InitializeHistogramFromConfig(std::string name, ChannelPair channel, std::vector<std::string>& histData) {
+void SelectorBase::InitializeHistogramFromConfig(
+    std::string name, ChannelPair channel, std::vector<std::string>& histData) {
     if (histData.size() != 4 && histData.size() != 7) {
-        std::cerr << "Malformed data string for histogram '" << name
-                    << ".' Must have form: 'Title; (optional info) $ nbins, xmin, xmax'"
-                    << "\n   OR form: 'Title; (optional info) $ nbins, xmin, xmax nbinsy ymin ymax'"
-                    << std::endl;
+        std::cerr
+            << "Malformed data string for histogram '" << name
+            << ".' Must have form: 'Title; (optional info) $ nbins, xmin, xmax'"
+            << "\n   OR form: 'Title; (optional info) $ nbins, xmin, xmax "
+               "nbinsy ymin ymax'"
+            << std::endl;
         exit(1);
     }
-    
+
     int nbins = std::stoi(histData.at(1));
     float xmin = std::stof(histData.at(2));
     float xmax = std::stof(histData.at(3));
-    
+
     bool is1D = histData.size() == 4;
     int nbinsy = is1D ? 1 : std::stoi(histData[4]);
     float ymin = is1D ? 1. : std::stof(histData[5]);
     float ymax = is1D ? 1. : std::stof(histData[6]);
 
     for (auto& variation : variations_) {
-        std::string histName = getHistName(name, variation.second, channel.second);
+        std::string histName =
+            getHistName(name, variation.second, channel.second);
         HistLabel histlabel = {name, channel.first, variation.first};
 
         if (variation.first == Central) {
-            if (is1D) 
-                AddObject<TH1D>(histMap1D_[histlabel], histName.c_str(), histData.at(0).c_str(),
-                        nbins, xmin, xmax);
+            if (is1D)
+                AddObject<TH1D>(histMap1D_[histlabel], histName.c_str(),
+                                histData.at(0).c_str(), nbins, xmin, xmax);
             else
-                AddObject<TH2D>(histMap2D_[histlabel], histName.c_str(), histData.at(0).c_str(), 
-                        nbins, xmin, xmax, nbinsy, ymin, ymax);
-        }
-        else if ((is1D && std::find(systHists_.begin(), systHists_.end(), name) == systHists_.end()) ||
-                    (!is1D && std::find(systHists2D_.begin(), systHists2D_.end(), name) == systHists2D_.end()))
+                AddObject<TH2D>(histMap2D_[histlabel], histName.c_str(),
+                                histData.at(0).c_str(), nbins, xmin, xmax,
+                                nbinsy, ymin, ymax);
+        } else if ((is1D && std::find(systHists_.begin(), systHists_.end(),
+                                      name) == systHists_.end()) ||
+                   (!is1D && std::find(systHists2D_.begin(), systHists2D_.end(),
+                                       name) == systHists2D_.end()))
             continue;
 
         if (is1D) {
             histMap1D_[histlabel] = {};
-            AddObject<TH1D>(histMap1D_[histlabel], histName.c_str(), 
-                histData.at(0).c_str(), nbins, xmin, xmax);
-        }
-        else {
+            AddObject<TH1D>(histMap1D_[histlabel], histName.c_str(),
+                            histData.at(0).c_str(), nbins, xmin, xmax);
+        } else {
             histMap1D_[histlabel] = {};
-            AddObject<TH2D>(histMap2D_[histlabel], histName.c_str(), 
-                histData.at(0).c_str(), nbins, xmin, xmax, nbinsy, ymin, ymax);
+            AddObject<TH2D>(histMap2D_[histlabel], histName.c_str(),
+                            histData.at(0).c_str(), nbins, xmin, xmax, nbinsy,
+                            ymin, ymax);
         }
 
-        if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(), variation.first) != theoryVarSysts_.end()) {
-            size_t pos = variation.first == Central ? name.size() : (name.size() + variation.second.size()+1);
+        if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(),
+                      variation.first) != theoryVarSysts_.end()) {
+            size_t pos = variation.first == Central
+                             ? name.size()
+                             : (name.size() + variation.second.size() + 1);
             std::string weighthistName = histName.insert(pos, "_lheWeights");
             int nweights = variation.first == Central ? 2000 : 20;
-            if (is1D && std::find(weighthists1D_.begin(), weighthists1D_.end(), name) != weighthists1D_.end()) {
+            if (is1D && std::find(weighthists1D_.begin(), weighthists1D_.end(),
+                                  name) != weighthists1D_.end()) {
                 weighthistMap1D_[histlabel] = {};
-                AddObject<TH2D>(weighthistMap1D_[histlabel], 
-                    weighthistName.c_str(), histData[0].c_str(),
-                    nbins, xmin, xmax, nweights, 0, nweights);
+                AddObject<TH2D>(weighthistMap1D_[histlabel],
+                                weighthistName.c_str(), histData[0].c_str(),
+                                nbins, xmin, xmax, nweights, 0, nweights);
             }
             // 3D weight hists must be subset of 2D hists!
-            else if (std::find(weighthists2D_.begin(), weighthists2D_.end(), name) != weighthists2D_.end()) {
+            else if (std::find(weighthists2D_.begin(), weighthists2D_.end(),
+                               name) != weighthists2D_.end()) {
                 weighthistMap2D_[histlabel] = {};
-                AddObject<TH3D>(weighthistMap2D_[histlabel], 
-                    weighthistName.c_str(), histData[0].c_str(),
-                    nbins, xmin, xmax, nbinsy, ymin, ymax, nweights, 0, nweights);
-
+                AddObject<TH3D>(weighthistMap2D_[histlabel],
+                                weighthistName.c_str(), histData[0].c_str(),
+                                nbins, xmin, xmax, nbinsy, ymin, ymax, nweights,
+                                0, nweights);
             }
         }
     }
 }
 
-std::vector<std::string> SelectorBase::ReadHistDataFromConfig(std::string histDataString) {
+std::vector<std::string> SelectorBase::ReadHistDataFromConfig(
+    std::string histDataString) {
     std::vector<std::string> histData;
     boost::split(histData, histDataString, boost::is_any_of("$"));
     std::vector<std::string> binInfo;
-    if (histData.size() != 2)
-        return {};
-    
+    if (histData.size() != 2) return {};
+
     boost::split(binInfo, histData[1], boost::is_any_of(","));
-   
+
     histData.pop_back();
     for (const auto& x : binInfo) {
         histData.push_back(x);
     }
-    
+
     return histData;
 }
 
-void SelectorBase::SetupNewDirectory()
-{
-}
+void SelectorBase::SetupNewDirectory() {}
 
-std::string SelectorBase::concatenateNames(const std::string& baseName, std::string& toAppend) {
+std::string SelectorBase::concatenateNames(const std::string& baseName,
+                                           std::string& toAppend) {
     return concatenateNames(baseName.c_str(), toAppend);
 }
 
-std::string SelectorBase::concatenateNames(const std::string& baseName, const char* toAppend) {
+std::string SelectorBase::concatenateNames(const std::string& baseName,
+                                           const char* toAppend) {
     std::string app = toAppend;
     return concatenateNames(baseName.c_str(), toAppend);
 }
 
-std::string SelectorBase::concatenateNames(const char* baseName, std::string& toAppend) {
-    if (toAppend.empty())
-        return baseName;
+std::string SelectorBase::concatenateNames(const char* baseName,
+                                           std::string& toAppend) {
+    if (toAppend.empty()) return baseName;
     const std::string delimit = "_";
     std::string name = baseName;
-    name.reserve(name.size()+delimit.size()+toAppend.size());
+    name.reserve(name.size() + delimit.size() + toAppend.size());
     name.append(delimit);
     name.append(toAppend);
     return name;
 }
 
-std::string SelectorBase::getHistName(std::string histName, std::string variationName) {
+std::string SelectorBase::getHistName(std::string histName,
+                                      std::string variationName) {
     return getHistName(histName, variationName, channelName_);
 }
 
-std::string SelectorBase::getHistName(std::string histName, std::string variationName, std::string channel) {
+std::string SelectorBase::getHistName(std::string histName,
+                                      std::string variationName,
+                                      std::string channel) {
     histName.append("_");
     if (!variationName.empty()) {
         histName.append(variationName);

--- a/src/TTTSelector.cc
+++ b/src/TTTSelector.cc
@@ -4,236 +4,237 @@
 #include <regex>
 #include "TParameter.h"
 
-#define Fill1D(NAME, VALUE_) HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
-#define Fill2D(NAME, VALUE1_, VALUE2_) HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
+#define Fill1D(NAME, VALUE_) \
+    HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
+#define Fill2D(NAME, VALUE1_, VALUE2_) \
+    HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
 
+enum Lepton { Muon = 13, Electron = 11 };
 
-
-enum Lepton {Muon=13, Electron=11};
-
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> LorentzVector;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
 void TTTSelector::SlaveBegin(TTree *) {
-  return;
-  pileupSF_ = (ScaleFactor *) GetInputList()->FindObject("pileupSF");
-  if (pileupSF_ == nullptr ) 
-    Abort("Must pass pileup weights SF");
-  eIdSF_ = (ScaleFactor *) GetInputList()->FindObject("electronTightIdSF");
-  if (eIdSF_ == nullptr ) 
-    Abort("Must pass electron ID SF");
-  eGsfSF_ = (ScaleFactor *) GetInputList()->FindObject("electronGsfSF");
-  if (eGsfSF_ == nullptr ) 
-    Abort("Must pass electron GSF SF");
-  mIdSF_ = (ScaleFactor *) GetInputList()->FindObject("muonTightIdSF");
-  if (mIdSF_ == nullptr ) 
-    Abort("Must pass muon ID SF");
-  mIsoSF_ = (ScaleFactor *) GetInputList()->FindObject("muonIsoSF");
-  if (mIsoSF_ == nullptr ) 
-    Abort("Must pass muon Iso SF");
+    return;
+    pileupSF_ = (ScaleFactor *)GetInputList()->FindObject("pileupSF");
+    if (pileupSF_ == nullptr) Abort("Must pass pileup weights SF");
+    eIdSF_ = (ScaleFactor *)GetInputList()->FindObject("electronTightIdSF");
+    if (eIdSF_ == nullptr) Abort("Must pass electron ID SF");
+    eGsfSF_ = (ScaleFactor *)GetInputList()->FindObject("electronGsfSF");
+    if (eGsfSF_ == nullptr) Abort("Must pass electron GSF SF");
+    mIdSF_ = (ScaleFactor *)GetInputList()->FindObject("muonTightIdSF");
+    if (mIdSF_ == nullptr) Abort("Must pass muon ID SF");
+    mIsoSF_ = (ScaleFactor *)GetInputList()->FindObject("muonIsoSF");
+    if (mIsoSF_ == nullptr) Abort("Must pass muon Iso SF");
 
-  prefireEff_ = (TEfficiency*) GetInputList()->FindObject("prefireEfficiencyMap");
-  if (prefireEff_ == nullptr ) 
-    Abort("Must pass prefiring efficiency map");
-
+    prefireEff_ =
+        (TEfficiency *)GetInputList()->FindObject("prefireEfficiencyMap");
+    if (prefireEff_ == nullptr) Abort("Must pass prefiring efficiency map");
 }
 
-void TTTSelector::Init(TTree *tree){
-  b.SetTree(tree);
-  
-  allChannels_ = {{ee, "ee"}, {mm, "mm"}, {em, "em"}, {all, "all"}};
- 
-  hists1D_ = {"CutFlow", "ZMass", "ptl1", "etal1", "ptl2", "etal2", "SR", "bjetpt", "jetpt", "nbjet", "njet", "jetphi","bjetphi", "phil1", "phil2","HT","MET", "nelec", "nmuon", "lept_charge", "before", "after", "nGoodParts"};
- hists2D_ = {"bJetvsJets"};
-  
-  SelectorBase::Init(tree);
-  
+void TTTSelector::Init(TTree *tree) {
+    b.SetTree(tree);
+
+    allChannels_ = {{ee, "ee"}, {mm, "mm"}, {em, "em"}, {all, "all"}};
+
+    hists1D_ = {"CutFlow", "ZMass",  "ptl1",      "etal1", "ptl2",
+                "etal2",   "SR",     "bjetpt",    "jetpt", "nbjet",
+                "njet",    "jetphi", "bjetphi",   "phil1", "phil2",
+                "HT",      "MET",    "nelec",     "nmuon", "lept_charge",
+                "before",  "after",  "nGoodParts"};
+    hists2D_ = {"bJetvsJets"};
+
+    SelectorBase::Init(tree);
 }
 
 void TTTSelector::SetBranchesNanoAOD() {
-  //  NECESSARY!!!!
-  b.CleanUp();
+    //  NECESSARY!!!!
+    b.CleanUp();
 
-  b.SetBranch("nElectron", nElectron);
-  b.SetBranch("Electron_pt", Electron_pt);
-  b.SetBranch("Electron_eta", Electron_eta);
-  b.SetBranch("Electron_phi", Electron_phi);
-  b.SetBranch("Electron_charge", Electron_charge);
-  b.SetBranch("Electron_mass", Electron_mass);
-  b.SetBranch("Electron_mass", Electron_miniPFRelIso_all);
-  b.SetBranch("Electron_miniPFRelIso_all", Electron_miniPFRelIso_all);
-  b.SetBranch("Electron_dxy", Electron_dxy);
-  b.SetBranch("Electron_dz", Electron_dz);
-  b.SetBranch("Electron_sip3d", Electron_sip3d);
-  if(year_ == yr2018) {
-    b.SetBranch("Electron_mvaFall17V2noIso", Electron_MVA);
-    b.SetBranch("Electron_cutBased", Electron_cutBased);
-  } else if(year_ == yr2017) {
-    b.SetBranch("Electron_mvaFall17V1noIso", Electron_MVA);
-    b.SetBranch("Electron_cutBased_Fall17_V1", Electron_cutBased);
-  } else if(year_ == yr2016 || year_ == yrdefault) {
-    b.SetBranch("Electron_mvaSpring16GP", Electron_MVA);
-    b.SetBranch("Electron_cutBased_Sum16", Electron_cutBased);
-  }
+    b.SetBranch("nElectron", nElectron);
+    b.SetBranch("Electron_pt", Electron_pt);
+    b.SetBranch("Electron_eta", Electron_eta);
+    b.SetBranch("Electron_phi", Electron_phi);
+    b.SetBranch("Electron_charge", Electron_charge);
+    b.SetBranch("Electron_mass", Electron_mass);
+    b.SetBranch("Electron_mass", Electron_miniPFRelIso_all);
+    b.SetBranch("Electron_miniPFRelIso_all", Electron_miniPFRelIso_all);
+    b.SetBranch("Electron_dxy", Electron_dxy);
+    b.SetBranch("Electron_dz", Electron_dz);
+    b.SetBranch("Electron_sip3d", Electron_sip3d);
+    if (year_ == yr2018) {
+        b.SetBranch("Electron_mvaFall17V2noIso", Electron_MVA);
+        b.SetBranch("Electron_cutBased", Electron_cutBased);
+    } else if (year_ == yr2017) {
+        b.SetBranch("Electron_mvaFall17V1noIso", Electron_MVA);
+        b.SetBranch("Electron_cutBased_Fall17_V1", Electron_cutBased);
+    } else if (year_ == yr2016 || year_ == yrdefault) {
+        b.SetBranch("Electron_mvaSpring16GP", Electron_MVA);
+        b.SetBranch("Electron_cutBased_Sum16", Electron_cutBased);
+    }
 
-  b.SetBranch("nMuon", nMuon);
-  b.SetBranch("Muon_pt", Muon_pt);
-  b.SetBranch("Muon_eta", Muon_eta);
-  b.SetBranch("Muon_phi", Muon_phi);
-  b.SetBranch("Muon_tightId", Muon_tightId);
-  b.SetBranch("Muon_mediumId", Muon_mediumId);
-  b.SetBranch("Muon_tkIsoId", Muon_tkIsoId);
-  b.SetBranch("Muon_pfRelIso04_all", Muon_pfRelIso04_all);
-  b.SetBranch("Muon_miniPFRelIso_all", Muon_miniPFRelIso_all);
-  b.SetBranch("Muon_charge", Muon_charge);
-  b.SetBranch("Muon_mass", Muon_mass);
-  b.SetBranch("Muon_dxy", Electron_dxy);
-  b.SetBranch("Muon_dz", Electron_dz);
-  b.SetBranch("Muon_sip3d", Electron_sip3d);
-  
-  b.SetBranch("nJet", nJet);
-  b.SetBranch("Jet_btagCSVV2", Jet_btagCSVV2);
-  b.SetBranch("Jet_btagDeepB", Jet_btagDeepB);
-  b.SetBranch("Jet_eta", Jet_eta);
-  b.SetBranch("Jet_phi", Jet_phi);
-  b.SetBranch("Jet_pt", Jet_pt);
-  b.SetBranch("Jet_mass", Jet_mass);
+    b.SetBranch("nMuon", nMuon);
+    b.SetBranch("Muon_pt", Muon_pt);
+    b.SetBranch("Muon_eta", Muon_eta);
+    b.SetBranch("Muon_phi", Muon_phi);
+    b.SetBranch("Muon_tightId", Muon_tightId);
+    b.SetBranch("Muon_mediumId", Muon_mediumId);
+    b.SetBranch("Muon_tkIsoId", Muon_tkIsoId);
+    b.SetBranch("Muon_pfRelIso04_all", Muon_pfRelIso04_all);
+    b.SetBranch("Muon_miniPFRelIso_all", Muon_miniPFRelIso_all);
+    b.SetBranch("Muon_charge", Muon_charge);
+    b.SetBranch("Muon_mass", Muon_mass);
+    b.SetBranch("Muon_dxy", Electron_dxy);
+    b.SetBranch("Muon_dz", Electron_dz);
+    b.SetBranch("Muon_sip3d", Electron_sip3d);
 
-  b.SetBranch("Jet_neHEF", Jet_neHEF);
-  b.SetBranch("Jet_neEmEF", Jet_neEmEF);
-  b.SetBranch("Jet_nConstituents", Jet_nConstituents);
-  b.SetBranch("Jet_chHEF", Jet_chHEF);
-  b.SetBranch("Jet_chEmEF", Jet_chEmEF);
+    b.SetBranch("nJet", nJet);
+    b.SetBranch("Jet_btagCSVV2", Jet_btagCSVV2);
+    b.SetBranch("Jet_btagDeepB", Jet_btagDeepB);
+    b.SetBranch("Jet_eta", Jet_eta);
+    b.SetBranch("Jet_phi", Jet_phi);
+    b.SetBranch("Jet_pt", Jet_pt);
+    b.SetBranch("Jet_mass", Jet_mass);
 
-  b.SetBranch("MET_pt", MET);
-  b.SetBranch("MET_phi", type1_pfMETPhi);
-  
-  if (isMC_) {
-    b.SetBranch("genWeight", genWeight);
-    b.SetBranch("Pileup_nPU", numPU);
-  }
-  
+    b.SetBranch("Jet_neHEF", Jet_neHEF);
+    b.SetBranch("Jet_neEmEF", Jet_neEmEF);
+    b.SetBranch("Jet_nConstituents", Jet_nConstituents);
+    b.SetBranch("Jet_chHEF", Jet_chHEF);
+    b.SetBranch("Jet_chEmEF", Jet_chEmEF);
+
+    b.SetBranch("MET_pt", MET);
+    b.SetBranch("MET_phi", type1_pfMETPhi);
+
+    if (isMC_) {
+        b.SetBranch("genWeight", genWeight);
+        b.SetBranch("Pileup_nPU", numPU);
+    }
 }
 
-void TTTSelector::SetBranchesUWVV() {
-  return;
-}
+void TTTSelector::SetBranchesUWVV() { return; }
 
-void TTTSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) {
-  return;
+void TTTSelector::LoadBranchesUWVV(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
+    return;
 }
 
 /// Make to seperate fuctionality
 void TTTSelector::clearValues() {
-  weight = 1;
-  HT = 0;
-  nTightJet = 0;
-  nBJets = 0;
-  goodParts.clear();
-  charge.clear();
+    weight = 1;
+    HT = 0;
+    nTightJet = 0;
+    nBJets = 0;
+    goodParts.clear();
+    charge.clear();
 }
 
-void TTTSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) { 
-  clearValues();
-  b.SetEntry(entry);
+void TTTSelector::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
+    clearValues();
+    b.SetEntry(entry);
 
-  if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_) {
-    std::string message = "Found more electrons or muons than max read number.\n    Found ";
-    message += std::to_string(nElectron);
-    message += " electrons.\n    Found ";
-    message += std::to_string(nMuon);
-    message += " Muons\n  --> Max read number was ";
-    message += std::to_string(N_KEEP_MU_E_);
-    message += "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ to avoid this error.\n";
-    throw std::domain_error(message);
-  }
-
-  /////////////////////
-  // Setup Electrons //
-  /////////////////////
-
-  for (size_t i = 0; i < nElectron; i++) {
-    // if(IsGoodMVAElectron2016(i)) {
-    if(IsGoodCBElectron(i)) {
-      // // Extra Iso requirement
-      // LorentzVector lep(Electron_pt[i], Electron_eta[i], Electron_phi[i], Electron_mass[i]);
-      // if(!passFullIso(lep, 0.8, 7.2)) continue;
-
-      // Setup goodPart
-      goodParts.push_back(GoodPart(Electron_pt[i], Electron_eta[i], Electron_phi[i], Electron_mass[i]));
-      goodParts.back().SetPdgId(Electron*Electron_charge[i]);
-      charge.push_back(Electron_charge[i]);
-    }
-  }
-
-  /////////////////
-  // Setup Muons //
-  /////////////////
-  
-  for (size_t i = 0; i < nMuon; i++) {
-    if(IsGoodMuon(i)) {
-      // // Extra Iso requirement
-      // LorentzVector lep(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]);
-      // if(!passFullIso(lep, 0.76, 7.2)) continue;
-
-      // Setup goodPart
-      goodParts.push_back(GoodPart(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]));
-      goodParts.back().SetPdgId(Muon*Muon_charge[i]);
-      charge.push_back(Muon_charge[i]);
-      
-    }
-  }
-  
-  ////////////////
-  // Setup Jets //
-  ////////////////
-  
-  for(size_t i = 0; i < nJet; i++) {
-    if(goodParts.size() != 2) break;
-
-    //common to both jets, may put more here
-    if(!isLooseJetId(i)) continue;
-
-    // regular jets
-    if(IsGoodJet(i)) {
-      nTightJet++;
-      HT += Jet_pt[i];
+    if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_) {
+        std::string message =
+            "Found more electrons or muons than max read number.\n    Found ";
+        message += std::to_string(nElectron);
+        message += " electrons.\n    Found ";
+        message += std::to_string(nMuon);
+        message += " Muons\n  --> Max read number was ";
+        message += std::to_string(N_KEEP_MU_E_);
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ "
+            "to avoid this error.\n";
+        throw std::domain_error(message);
     }
 
-    // bjet 
-    if(IsGoodBJet(i)) nBJets++;
-  }
+    /////////////////////
+    // Setup Electrons //
+    /////////////////////
 
-  channel_ = channelMap_[channelName_];
-  if(goodParts.size() != 2) {
-    channel_ = Unknown;
-    channelName_ = "Unknown";
-  } else if(goodParts[0].Id() == Muon && goodParts[1].Id() == Muon) {
-    channel_ = mm;
-    channelName_ = "mm";
-  } else if(goodParts[0].Id() == Electron && goodParts[1].Id() == Electron) {
-    channel_ = ee;
-    channelName_ = "ee";
-  } else {
-    channel_ = em;
-    channelName_ ="em";
-    /// fix order of leptons by pt
-    if(goodParts[0].Pt() < goodParts[1].Pt()) {
-      std::swap(goodParts[0], goodParts[1]);
+    for (size_t i = 0; i < nElectron; i++) {
+        // if(IsGoodMVAElectron2016(i)) {
+        if (IsGoodCBElectron(i)) {
+            // // Extra Iso requirement
+            // LorentzVector lep(Electron_pt[i], Electron_eta[i],
+            // Electron_phi[i], Electron_mass[i]); if(!passFullIso(lep,
+            // 0.8, 7.2)) continue;
+
+            // Setup goodPart
+            goodParts.push_back(GoodPart(Electron_pt[i], Electron_eta[i],
+                                         Electron_phi[i], Electron_mass[i]));
+            goodParts.back().SetPdgId(Electron * Electron_charge[i]);
+            charge.push_back(Electron_charge[i]);
+        }
     }
-  }
 
-  if (isMC_) {
-    ApplyScaleFactors();
-  }
+    /////////////////
+    // Setup Muons //
+    /////////////////
+
+    for (size_t i = 0; i < nMuon; i++) {
+        if (IsGoodMuon(i)) {
+            // // Extra Iso requirement
+            // LorentzVector lep(Muon_pt[i], Muon_eta[i], Muon_phi[i],
+            // Muon_mass[i]); if(!passFullIso(lep, 0.76, 7.2)) continue;
+
+            // Setup goodPart
+            goodParts.push_back(
+                GoodPart(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]));
+            goodParts.back().SetPdgId(Muon * Muon_charge[i]);
+            charge.push_back(Muon_charge[i]);
+        }
+    }
+
+    ////////////////
+    // Setup Jets //
+    ////////////////
+
+    for (size_t i = 0; i < nJet; i++) {
+        if (goodParts.size() != 2) break;
+
+        // common to both jets, may put more here
+        if (!isLooseJetId(i)) continue;
+
+        // regular jets
+        if (IsGoodJet(i)) {
+            nTightJet++;
+            HT += Jet_pt[i];
+        }
+
+        // bjet
+        if (IsGoodBJet(i)) nBJets++;
+    }
+
+    channel_ = channelMap_[channelName_];
+    if (goodParts.size() != 2) {
+        channel_ = Unknown;
+        channelName_ = "Unknown";
+    } else if (goodParts[0].Id() == Muon && goodParts[1].Id() == Muon) {
+        channel_ = mm;
+        channelName_ = "mm";
+    } else if (goodParts[0].Id() == Electron && goodParts[1].Id() == Electron) {
+        channel_ = ee;
+        channelName_ = "ee";
+    } else {
+        channel_ = em;
+        channelName_ = "em";
+        /// fix order of leptons by pt
+        if (goodParts[0].Pt() < goodParts[1].Pt()) {
+            std::swap(goodParts[0], goodParts[1]);
+        }
+    }
+
+    if (isMC_) {
+        ApplyScaleFactors();
+    }
 }
-
 
 void TTTSelector::ApplyScaleFactors() {
-  weight *= (genWeight > 0) ? 1.0 : -1.0;
-  //  weight = 1;
-  // skipping for now
-  return;
-  //// to add!!
+    weight *= (genWeight > 0) ? 1.0 : -1.0;
+    //  weight = 1;
+    // skipping for now
+    return;
+    //// to add!!
 }
 
 ////////////////////////////////////////////////////
@@ -241,244 +242,226 @@ void TTTSelector::ApplyScaleFactors() {
 // loop of leptons/jets for getting multiplicity  //
 ////////////////////////////////////////////////////
 
-
-
 bool TTTSelector::IsGoodMuon(size_t index) {
-  return ( (Muon_pt[index] > 20) &&
-	   (abs(Muon_eta[index]) < 2.4) &&
-	   Muon_mediumId[index] &&
-	   (Muon_miniPFRelIso_all[index] < 0.16) &&
-	   (Muon_dz[index] < 0.1) &&
-	   (Muon_dxy[index] < 0.05) &&
-	   (Muon_sip3d[index] < 4));
+    return ((Muon_pt[index] > 20) && (abs(Muon_eta[index]) < 2.4) &&
+            Muon_mediumId[index] && (Muon_miniPFRelIso_all[index] < 0.16) &&
+            (Muon_dz[index] < 0.1) && (Muon_dxy[index] < 0.05) &&
+            (Muon_sip3d[index] < 4));
 }
 
 bool TTTSelector::IsGoodCBElectron(size_t index) {
-  return ((Electron_pt[index] > 20) &&
-	  (abs(Electron_eta[index]) < 2.5) &&
-	  (Electron_miniPFRelIso_all[index] < 0.12) &&
-	  (Electron_cutBased[index] == 4)  &&
-	  (Electron_dz[index] < 0.1) &&
-	  (Electron_dxy[index] < 0.05) &&
-	  (Electron_sip3d[index] < 4));
+    return ((Electron_pt[index] > 20) && (abs(Electron_eta[index]) < 2.5) &&
+            (Electron_miniPFRelIso_all[index] < 0.12) &&
+            (Electron_cutBased[index] == 4) && (Electron_dz[index] < 0.1) &&
+            (Electron_dxy[index] < 0.05) && (Electron_sip3d[index] < 4));
 }
 
 bool TTTSelector::IsGoodMVAElectron2016(size_t index) {
-  bool mvaRec = false;
-  if(abs(Electron_eta[index]) < 0.8)
-    mvaRec = Electron_MVA[index] > std::max(0.52, 0.77-0.025*(Electron_pt[index]-15));
-  else if(abs(Electron_eta[index]) < 1.479)
-    mvaRec = Electron_MVA[index] > std::max(0.11, 0.56-0.045*(Electron_pt[index]-15));
-  else if(abs(Electron_eta[index]) < 2.5)
-    mvaRec = Electron_MVA[index] > std::max(-0.01, 0.48-0.049*(Electron_pt[index]-15));
+    bool mvaRec = false;
+    if (abs(Electron_eta[index]) < 0.8)
+        mvaRec = Electron_MVA[index] >
+                 std::max(0.52, 0.77 - 0.025 * (Electron_pt[index] - 15));
+    else if (abs(Electron_eta[index]) < 1.479)
+        mvaRec = Electron_MVA[index] >
+                 std::max(0.11, 0.56 - 0.045 * (Electron_pt[index] - 15));
+    else if (abs(Electron_eta[index]) < 2.5)
+        mvaRec = Electron_MVA[index] >
+                 std::max(-0.01, 0.48 - 0.049 * (Electron_pt[index] - 15));
 
-  return ((Electron_pt[index] > 20) &&
-	  (Electron_miniPFRelIso_all[index] < 0.12) &&
-	  (mvaRec)  &&
-	  (Electron_dz[index] < 0.1) &&
-	  (Electron_dxy[index] < 0.05) &&
-	  (Electron_sip3d[index] < 4) );
+    return ((Electron_pt[index] > 20) &&
+            (Electron_miniPFRelIso_all[index] < 0.12) && (mvaRec) &&
+            (Electron_dz[index] < 0.1) && (Electron_dxy[index] < 0.05) &&
+            (Electron_sip3d[index] < 4));
 }
 
 bool TTTSelector::IsGoodMVAElectron2017(size_t index) {
-  bool mvaRec = false;
-  if(abs(Electron_eta[index]) < 0.8)
-    mvaRec = std::max(0.52, 0.77-0.025*(Electron_pt[index]-15));
-  else if(abs(Electron_eta[index]) < 1.479)
-    mvaRec = std::max(0.11, 0.56-0.045*(Electron_pt[index]-15));
-  else if(abs(Electron_eta[index]) < 2.5)
-    mvaRec = std::max(-0.01, 0.48-0.049*(Electron_pt[index]-15));
+    bool mvaRec = false;
+    if (abs(Electron_eta[index]) < 0.8)
+        mvaRec = std::max(0.52, 0.77 - 0.025 * (Electron_pt[index] - 15));
+    else if (abs(Electron_eta[index]) < 1.479)
+        mvaRec = std::max(0.11, 0.56 - 0.045 * (Electron_pt[index] - 15));
+    else if (abs(Electron_eta[index]) < 2.5)
+        mvaRec = std::max(-0.01, 0.48 - 0.049 * (Electron_pt[index] - 15));
 
-  return ((Electron_pt[index] > 20) &&
-	  mvaRec);
+    return ((Electron_pt[index] > 20) && mvaRec);
 }
 
-//40
+// 40
 bool TTTSelector::IsGoodJet(size_t index) {
-  return ((Jet_pt[index] > 40) &&
-	  (abs(Jet_eta[index]) < 2.4) &&
-	  isOverlap(index)
-	  );
+    return ((Jet_pt[index] > 40) && (abs(Jet_eta[index]) < 2.4) &&
+            isOverlap(index));
 }
 
 /// TODO: add toggle for different btag stuff
 
-//25
+// 25
 bool TTTSelector::IsGoodBJet(size_t index) {
-  return ((Jet_pt[index] > 25) &&
-	  (abs(Jet_eta[index]) < 2.4) &&
-	  (Jet_btagCSVV2[index] > 0.8484) &&  
-	  //(Jet_btagDeepB[index] > 0.6324) &&
-	  isOverlap(index)
-	  );
+    return ((Jet_pt[index] > 25) && (abs(Jet_eta[index]) < 2.4) &&
+            (Jet_btagCSVV2[index] > 0.8484) &&
+            //(Jet_btagDeepB[index] > 0.6324) &&
+            isOverlap(index));
 }
 
 bool TTTSelector::isLooseJetId(size_t index) {
-  return (Jet_neHEF[index] < 0.99 &&
-	  Jet_neEmEF[index] < 0.99 &&
-	  Jet_nConstituents[index] > 1 &&
-	  Jet_chHEF[index] > 0 &&
-	  Jet_chEmEF[index] < 0.99
-	  );
+    return (Jet_neHEF[index] < 0.99 && Jet_neEmEF[index] < 0.99 &&
+            Jet_nConstituents[index] > 1 && Jet_chHEF[index] > 0 &&
+            Jet_chEmEF[index] < 0.99);
 }
 
 bool TTTSelector::isTightJetId(size_t index) {
-  return ((Jet_neHEF[index] < 0.9) &&
-	  (Jet_neEmEF[index] < 0.9) &&
-	  (Jet_nConstituents[index] > 1) &&
-	  (Jet_chHEF[index] > 0)
-	  );
+    return ((Jet_neHEF[index] < 0.9) && (Jet_neEmEF[index] < 0.9) &&
+            (Jet_nConstituents[index] > 1) && (Jet_chHEF[index] > 0));
 }
 
-bool TTTSelector::passFullIso(LorentzVector& lep, int I2, int I3) {
-  LorentzVector closeJet;
-  double minDR = 10;
-  for(size_t index = 0; index < nJet; index++) {
-    LorentzVector jet(Jet_pt[index], Jet_eta[index], Jet_phi[index], Jet_mass[index]);
-    double dr = reco::deltaR(jet, lep);
-    if(minDR > dr) {
-      closeJet = jet;
-      minDR = dr;
+bool TTTSelector::passFullIso(LorentzVector &lep, int I2, int I3) {
+    LorentzVector closeJet;
+    double minDR = 10;
+    for (size_t index = 0; index < nJet; index++) {
+        LorentzVector jet(Jet_pt[index], Jet_eta[index], Jet_phi[index],
+                          Jet_mass[index]);
+        double dr = reco::deltaR(jet, lep);
+        if (minDR > dr) {
+            closeJet = jet;
+            minDR = dr;
+        }
     }
-  }
-  
-  if(lep.Pt()/closeJet.Pt() > I2 ) return true;
-  
-  auto diff = closeJet.Vect() - lep.Vect();
-  auto cross = diff.Cross(lep.Vect());
-  return (cross.Mag2()/diff.Mag2() > I3*I3);
+
+    if (lep.Pt() / closeJet.Pt() > I2) return true;
+
+    auto diff = closeJet.Vect() - lep.Vect();
+    auto cross = diff.Cross(lep.Vect());
+    return (cross.Mag2() / diff.Mag2() > I3 * I3);
 }
 
 bool TTTSelector::isOverlap(size_t index) {
-  LorentzVector tmp(Jet_pt[index], Jet_eta[index], Jet_phi[index], Jet_mass[index]);
-  double dR = 0.4;
-  bool passOverlap = true;
-  for(auto lep: goodParts) {
-    passOverlap = (reco::deltaR(tmp, lep.v) > dR);
-    if(!passOverlap) return false;
-  }
-  return true;
+    LorentzVector tmp(Jet_pt[index], Jet_eta[index], Jet_phi[index],
+                      Jet_mass[index]);
+    double dR = 0.4;
+    bool passOverlap = true;
+    for (auto lep : goodParts) {
+        passOverlap = (reco::deltaR(tmp, lep.v) > dR);
+        if (!passOverlap) return false;
+    }
+    return true;
 }
 
-void TTTSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) {
-  
-  int step = 0;
-  Fill1D("CutFlow", 0);
+void TTTSelector::FillHistograms(Long64_t entry,
+                                 std::pair<Systematic, std::string> variation) {
+    int step = 0;
+    Fill1D("CutFlow", 0);
 
-  Fill1D("nGoodParts", goodParts.size());
-  
-  /// 2 good leptons
-  if(goodParts.size() != 2) return;
-  Fill1D("CutFlow", ++step);
+    Fill1D("nGoodParts", goodParts.size());
 
-  
-  // std::cout<<"charge array : " <<charge[0]<<""<< charge[1]<<std::endl;
-  if(goodParts[0].Charge() * goodParts[1].Charge() >= 0) 
-    Fill1D("before", 0);
-   
-  if(goodParts[0].Charge() * goodParts[1].Charge() <= 0) 
-    Fill1D("before", 1);
-   
-  // first lep requirement 
-  if(goodParts[0].Pt() < 25) return;
-  Fill1D("CutFlow", ++step);
-  
-  // same sign requirement
-  // if(goodParts[0].Charge() * goodParts[1].Charge() <= 0) return;
-  Fill1D("CutFlow", ++step);
+    /// 2 good leptons
+    if (goodParts.size() != 2) return;
+    Fill1D("CutFlow", ++step);
 
-  // met cut 50
-  if (MET < 50) return;
-  Fill1D("CutFlow", ++step);
+    // std::cout<<"charge array : " <<charge[0]<<""<< charge[1]<<std::endl;
+    if (goodParts[0].Charge() * goodParts[1].Charge() >= 0) Fill1D("before", 0);
 
-  // ht cut 
-  if(HT <300 ) return;
-  Fill1D("CutFlow", ++step);
-  
-  // jet cut 4
-  if(nTightJet < 4) return;
-  Fill1D("CutFlow", ++step);
-  
-  // bjet cut 2
-  if(nBJets < 2) return;
-  Fill1D("CutFlow", ++step);
+    if (goodParts[0].Charge() * goodParts[1].Charge() <= 0) Fill1D("before", 1);
 
-  if(goodParts[0].Charge() * goodParts[1].Charge() >= 0)
-    Fill1D("after", 0);
-  if(goodParts[0].Charge() * goodParts[1].Charge() <=0)
-    Fill1D("after", 1);
- 
-  // // veto cut
-  // if(!passesLeptonVeto)
-  //   Fill1D("CutFlow", ++step);
-  // in SR stuff
-  
-  Fill1D("ptl1", goodParts[0].Pt());
-  Fill1D("ptl2", goodParts[1].Pt());
-  Fill1D("SR", getSRBin());
-  Fill1D("njet", nTightJet);
-  Fill1D("nbjet", nBJets);
-  Fill1D("phil1", goodParts[0].Phi());
-  Fill1D("phil2", goodParts[1].Phi());
-  Fill1D("HT", HT );
-  Fill1D("MET", MET);
-  Fill1D("nelec", nElectron);
-  Fill1D("nmuon", nMuon);
-  Fill1D("lept_charge", charge[0]);
-  Fill1D("lept_charge", charge[1]);
+    // first lep requirement
+    if (goodParts[0].Pt() < 25) return;
+    Fill1D("CutFlow", ++step);
 
-  Fill2D("bJetvsJets", nTightJet, nBJets);
-  
+    // same sign requirement
+    // if(goodParts[0].Charge() * goodParts[1].Charge() <= 0) return;
+    Fill1D("CutFlow", ++step);
 
-  for(size_t i = 0; i < nJet; i++) {
-    if(IsGoodJet(i)) {
-      Fill1D("jetpt", Jet_pt[i]);
-      Fill1D("jetphi",Jet_phi[i]);
+    // met cut 50
+    if (MET < 50) return;
+    Fill1D("CutFlow", ++step);
+
+    // ht cut
+    if (HT < 300) return;
+    Fill1D("CutFlow", ++step);
+
+    // jet cut 4
+    if (nTightJet < 4) return;
+    Fill1D("CutFlow", ++step);
+
+    // bjet cut 2
+    if (nBJets < 2) return;
+    Fill1D("CutFlow", ++step);
+
+    if (goodParts[0].Charge() * goodParts[1].Charge() >= 0) Fill1D("after", 0);
+    if (goodParts[0].Charge() * goodParts[1].Charge() <= 0) Fill1D("after", 1);
+
+    // // veto cut
+    // if(!passesLeptonVeto)
+    //   Fill1D("CutFlow", ++step);
+    // in SR stuff
+
+    Fill1D("ptl1", goodParts[0].Pt());
+    Fill1D("ptl2", goodParts[1].Pt());
+    Fill1D("SR", getSRBin());
+    Fill1D("njet", nTightJet);
+    Fill1D("nbjet", nBJets);
+    Fill1D("phil1", goodParts[0].Phi());
+    Fill1D("phil2", goodParts[1].Phi());
+    Fill1D("HT", HT);
+    Fill1D("MET", MET);
+    Fill1D("nelec", nElectron);
+    Fill1D("nmuon", nMuon);
+    Fill1D("lept_charge", charge[0]);
+    Fill1D("lept_charge", charge[1]);
+
+    Fill2D("bJetvsJets", nTightJet, nBJets);
+
+    for (size_t i = 0; i < nJet; i++) {
+        if (IsGoodJet(i)) {
+            Fill1D("jetpt", Jet_pt[i]);
+            Fill1D("jetphi", Jet_phi[i]);
+        }
+        if (IsGoodBJet(i)) {
+            Fill1D("bjetpt", Jet_pt[i]);
+            Fill1D("bjetphi", Jet_phi[i]);
+        }
     }
-    if(IsGoodBJet(i)) {
-      Fill1D("bjetpt", Jet_pt[i]);
-      Fill1D("bjetphi",Jet_phi[i]);
-    }
-  }
- }
+}
 
 void TTTSelector::SetupNewDirectory() {
-  SelectorBase::SetupNewDirectory();
+    SelectorBase::SetupNewDirectory();
 
-  InitializeHistogramsFromConfig();
+    InitializeHistogramsFromConfig();
 }
 
 int TTTSelector::getSRBin() {
-  if(nBJets == 2) {
-    if(nTightJet <= 5)      return 0;
-    if(nTightJet == 6)      return 1;
-    else if(nTightJet == 7) return 2;
-    else if(nTightJet >= 8) return 3;
-  } else if(nBJets == 3) {
-    if(nTightJet == 5)      return 4;
-    else if(nTightJet == 6) return 4;
-    else if(nTightJet == 7) return 5;
-    else if(nTightJet >= 8) return 5;
-  } else if(nBJets >= 4) {
-    if(nTightJet >= 5)     return 6;
-  }
-  return -1;
+    if (nBJets == 2) {
+        if (nTightJet <= 5) return 0;
+        if (nTightJet == 6)
+            return 1;
+        else if (nTightJet == 7)
+            return 2;
+        else if (nTightJet >= 8)
+            return 3;
+    } else if (nBJets == 3) {
+        if (nTightJet == 5)
+            return 4;
+        else if (nTightJet == 6)
+            return 4;
+        else if (nTightJet == 7)
+            return 5;
+        else if (nTightJet >= 8)
+            return 5;
+    } else if (nBJets >= 4) {
+        if (nTightJet >= 5) return 6;
+    }
+    return -1;
 
-  // if(nBJets == 2) {
-  //   if(nTightJet <= 5)      return 0;
-  //   if(nTightJet == 6)      return 1;
-  //   else if(nTightJet == 7) return 2;
-  //   else if(nTightJet >= 8) return 3;
-  // } else if(nBJets == 3) {
-  //   if(nTightJet == 5)      return 4;
-  //   else if(nTightJet == 6) return 5;
-  //   else if(nTightJet == 7) return 6;
-  //   else if(nTightJet >= 8) return 7;
-  // } else if(nBJets >= 4) {
-  //   if(nTightJet >= 5)     return 8;
-  // }
-  // return -1;
-
-  
- }
-
+    // if(nBJets == 2) {
+    //   if(nTightJet <= 5)      return 0;
+    //   if(nTightJet == 6)      return 1;
+    //   else if(nTightJet == 7) return 2;
+    //   else if(nTightJet >= 8) return 3;
+    // } else if(nBJets == 3) {
+    //   if(nTightJet == 5)      return 4;
+    //   else if(nTightJet == 6) return 5;
+    //   else if(nTightJet == 7) return 6;
+    //   else if(nTightJet >= 8) return 7;
+    // } else if(nBJets >= 4) {
+    //   if(nTightJet >= 5)     return 8;
+    // }
+    // return -1;
+}

--- a/src/ThreeLepSelector.cc
+++ b/src/ThreeLepSelector.cc
@@ -5,20 +5,29 @@
 #include <regex>
 #include "TParameter.h"
 
-#define Fill1D(NAME, VALUE_) HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
-#define Fill2D(NAME, VALUE1_, VALUE2_) HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
+#define Fill1D(NAME, VALUE_) \
+    HistFullFill(histMap1D_, NAME, variation.first, VALUE_, weight);
+#define Fill2D(NAME, VALUE1_, VALUE2_) \
+    HistFullFill(histMap2D_, NAME, variation.first, VALUE1_, VALUE2_, weight);
 
 #define GETMASK(index, size) (((1 << (size)) - 1) << (index))
-#define READFROM(data, index, size) (((data) & GETMASK((index), (size))) >> (index))
+#define READFROM(data, index, size) \
+    (((data)&GETMASK((index), (size))) >> (index))
 
 #define CHGPT(index) (Electron_eCorr[index])
 #define CLOSEJET_REWEIGHT
 
 typedef std::bitset<sizeof(int)> IntBits;
 
-enum ElectronCBID {CBID_VETO=1, CBID_LOOSE=2, CBID_MEDIUM=3, CBID_TIGHT=4};
+enum ElectronCBID {
+    CBID_VETO = 1,
+    CBID_LOOSE = 2,
+    CBID_MEDIUM = 3,
+    CBID_TIGHT = 4
+};
 
-typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>> LorentzVector;
+typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double>>
+    LorentzVector;
 
 void ThreeLepSelector::SetScaleFactors() {
     calib = BTagCalibration("deepcsv", "data/btag_scales.csv");
@@ -27,9 +36,8 @@ void ThreeLepSelector::SetScaleFactors() {
     btag_reader.load(calib, BTagEntry::FLAV_C, "comb");
     btag_reader.load(calib, BTagEntry::FLAV_UDSG, "incl");
 
-    pileupSF_ = (ScaleFactor *) GetInputList()->FindObject("pileupSF");
-    if (pileupSF_ == nullptr )
-	std::cout << "missing Pileup SF" << std::endl;
+    pileupSF_ = (ScaleFactor*)GetInputList()->FindObject("pileupSF");
+    if (pileupSF_ == nullptr) std::cout << "missing Pileup SF" << std::endl;
 
     // TFile* bFile = (TFile*) GetInputList()->FindObject("BScales");
     // name_ = GetInputList()->FindObject("name")->GetTitle();
@@ -37,33 +45,35 @@ void ThreeLepSelector::SetScaleFactors() {
     // Beff_j = (TH2D*) bFile->Get((name_ + "/Beff_j").c_str());
     // Beff_b = (TH2D*) bFile->Get((name_ + "/Beff_b").c_str());
 
-    eIdSF_ = (ScaleFactor *) GetInputList()->FindObject("electronTightIdSF");
-    if (eIdSF_ == nullptr )
-	std::cout  << "missing Electron ID SF" << std::endl;
+    eIdSF_ = (ScaleFactor*)GetInputList()->FindObject("electronTightIdSF");
+    if (eIdSF_ == nullptr) std::cout << "missing Electron ID SF" << std::endl;
 
-    mIdSF_ = (ScaleFactor *) GetInputList()->FindObject("muonMediumIdSF");
-    if (mIdSF_ == nullptr )
-	std::cout  << "missing Muon Id SF" << std::endl;
+    mIdSF_ = (ScaleFactor*)GetInputList()->FindObject("muonMediumIdSF");
+    if (mIdSF_ == nullptr) std::cout << "missing Muon Id SF" << std::endl;
 
-    TFile* f_btag_eff = new TFile("ScaleFactors/btageff__ttbar_powheg_pythia8_25ns_Moriond17_deepCSV.root");
-    h_btag_eff_b    = (TH2D*) f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_b");
-    h_btag_eff_c    = (TH2D*) f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_c");
-    h_btag_eff_udsg = (TH2D*) f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_udsg");
-
+    TFile* f_btag_eff = new TFile(
+        "ScaleFactors/"
+        "btageff__ttbar_powheg_pythia8_25ns_Moriond17_deepCSV.root");
+    h_btag_eff_b = (TH2D*)f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_b");
+    h_btag_eff_c = (TH2D*)f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_c");
+    h_btag_eff_udsg = (TH2D*)f_btag_eff->Get("h2_BTaggingEff_csv_med_Eff_udsg");
 }
 
-void ThreeLepSelector::Init(TTree *tree) {
+void ThreeLepSelector::Init(TTree* tree) {
     b.SetTree(tree);
 
-    allChannels_ = {{mm, "mm"}, {ee, "ee"}, {em, "em"}, {all, "all"}, {lll, "lll"}};
+    allChannels_ = {
+        {mm, "mm"}, {ee, "ee"}, {em, "em"}, {all, "all"}, {lll, "lll"}};
 
     hists1D_ = {
-		"CutFlow",      "ZMass",       "ptl1",     "etal1",    "ptl2",     "etal2",        "SR",
-		"bjetpt",       "jetpt",       "nbjet",    "njet",     "nleps",    "CRW_nbjet",    "CRW_njet",
-		"CRZ_nbjet",    "CRZ_njet",    "CRZ_HT",   "CRZ_Met",  "Met",      "HT",           "weight",
-		"CRW_HT",       "CRW_Met",     "CRZ_ptl3", "sphericity", "centrality",
+        "CutFlow",    "ZMass",  "ptl1",      "etal1",    "ptl2",
+        "etal2",      "SR",     "bjetpt",    "jetpt",    "nbjet",
+        "njet",       "nleps",  "CRW_nbjet", "CRW_njet", "CRZ_nbjet",
+        "CRZ_njet",   "CRZ_HT", "CRZ_Met",   "Met",      "HT",
+        "weight",     "CRW_HT", "CRW_Met",   "CRZ_ptl3", "sphericity",
+        "centrality",
     };
-    hists2D_ = {"bJetvsJets",    "Beff_b_btag", "Beff_j_btag", "Beff_b", "Beff_j"};
+    hists2D_ = {"bJetvsJets", "Beff_b_btag", "Beff_j_btag", "Beff_b", "Beff_j"};
 
     SelectorBase::Init(tree);
 }
@@ -71,116 +81,120 @@ void ThreeLepSelector::Init(TTree *tree) {
 void ThreeLepSelector::SetBranchesNanoAOD() {
     //  NECESSARY!!!!
     b.CleanUp();
-    
+
     b.SetBranch("HLT_DoubleMu8_Mass8_PFHT300", HLT_DoubleMu8_Mass8_PFHT300);
-    b.SetBranch("HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300", HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300);
-    b.SetBranch("HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300", HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300);
+    b.SetBranch("HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300",
+                HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300);
+    b.SetBranch("HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300",
+                HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300);
     b.SetBranch("HLT_AK8PFJet450", HLT_AK8PFJet450);
     b.SetBranch("HLT_PFJet450", HLT_PFJet450);
 
-    b.SetBranch("nElectron",                  nElectron);
-    b.SetBranch("Electron_pt",                Electron_pt);
-    b.SetBranch("Electron_eta",               Electron_eta);
-    b.SetBranch("Electron_phi",               Electron_phi);
-    b.SetBranch("Electron_charge",            Electron_charge);
-    b.SetBranch("Electron_mass",              Electron_mass);
-    b.SetBranch("Electron_miniPFRelIso_all",  Electron_miniPFRelIso_all);
-    b.SetBranch("Electron_dxy",               Electron_dxy);
-    b.SetBranch("Electron_dz",                Electron_dz);
-    b.SetBranch("Electron_sip3d",             Electron_sip3d);
-    b.SetBranch("Electron_lostHits",          Electron_lostHits);
-    b.SetBranch("Electron_convVeto",          Electron_convVeto);
-    if(year_ == yr2018) {
-	b.SetBranch("Electron_mvaFall17V2noIso",     Electron_MVA);
-	b.SetBranch("Electron_cutBased",             Electron_cutBased);
-    } else if(year_ == yr2017) {
-	b.SetBranch("Electron_mvaFall17noIso",     Electron_MVA);
-	b.SetBranch("Electron_cutBased",   Electron_cutBased);
-    } else if(year_ == yr2016 || year_ == yrdefault) {
-	b.SetBranch("Electron_mvaSpring16GP",        Electron_MVA);
-	b.SetBranch("Electron_cutBased_Sum16",       Electron_cutBased);
+    b.SetBranch("nElectron", nElectron);
+    b.SetBranch("Electron_pt", Electron_pt);
+    b.SetBranch("Electron_eta", Electron_eta);
+    b.SetBranch("Electron_phi", Electron_phi);
+    b.SetBranch("Electron_charge", Electron_charge);
+    b.SetBranch("Electron_mass", Electron_mass);
+    b.SetBranch("Electron_miniPFRelIso_all", Electron_miniPFRelIso_all);
+    b.SetBranch("Electron_dxy", Electron_dxy);
+    b.SetBranch("Electron_dz", Electron_dz);
+    b.SetBranch("Electron_sip3d", Electron_sip3d);
+    b.SetBranch("Electron_lostHits", Electron_lostHits);
+    b.SetBranch("Electron_convVeto", Electron_convVeto);
+    if (year_ == yr2018) {
+        b.SetBranch("Electron_mvaFall17V2noIso", Electron_MVA);
+        b.SetBranch("Electron_cutBased", Electron_cutBased);
+    } else if (year_ == yr2017) {
+        b.SetBranch("Electron_mvaFall17noIso", Electron_MVA);
+        b.SetBranch("Electron_cutBased", Electron_cutBased);
+    } else if (year_ == yr2016 || year_ == yrdefault) {
+        b.SetBranch("Electron_mvaSpring16GP", Electron_MVA);
+        b.SetBranch("Electron_cutBased_Sum16", Electron_cutBased);
     }
     b.SetBranch("Electron_tightCharge", Electron_tightCharge);
-    b.SetBranch("Electron_sieie",                        Electron_sieie);
-    b.SetBranch("Electron_hoe",                          Electron_hoe);
-    b.SetBranch("Electron_deltaEtaSC",                   Electron_deltaEtaSC);
-    b.SetBranch("Electron_eInvMinusPInv",                Electron_eInvMinusPInv);
-    b.SetBranch("Electron_dr03EcalRecHitSumEt",          Electron_dr03EcalRecHitSumEt);
-    b.SetBranch("Electron_dr03HcalDepth1TowerSumEt",     Electron_dr03HcalDepth1TowerSumEt);
-    b.SetBranch("Electron_dr03TkSumPt",                  Electron_dr03TkSumPt);
+    b.SetBranch("Electron_sieie", Electron_sieie);
+    b.SetBranch("Electron_hoe", Electron_hoe);
+    b.SetBranch("Electron_deltaEtaSC", Electron_deltaEtaSC);
+    b.SetBranch("Electron_eInvMinusPInv", Electron_eInvMinusPInv);
+    b.SetBranch("Electron_dr03EcalRecHitSumEt", Electron_dr03EcalRecHitSumEt);
+    b.SetBranch("Electron_dr03HcalDepth1TowerSumEt",
+                Electron_dr03HcalDepth1TowerSumEt);
+    b.SetBranch("Electron_dr03TkSumPt", Electron_dr03TkSumPt);
     b.SetBranch("Electron_vidNestedWPBitmapSum16", Electron_vidBitmap);
     b.SetBranch("Electron_eCorr", Electron_eCorr);
-    
-    b.SetBranch("nMuon",                  nMuon);
-    b.SetBranch("Muon_pt",                Muon_pt);
-    b.SetBranch("Muon_eta",               Muon_eta);
-    b.SetBranch("Muon_phi",               Muon_phi);
-    b.SetBranch("Muon_mass",              Muon_mass);
-    b.SetBranch("Muon_charge",            Muon_charge);
-    b.SetBranch("Muon_mediumId",          Muon_mediumId);
-    b.SetBranch("Muon_miniPFRelIso_all",  Muon_miniPFRelIso_all);
-    b.SetBranch("Muon_dxy",               Muon_dxy);
-    b.SetBranch("Muon_dz",                Muon_dz);
-    b.SetBranch("Muon_sip3d",             Muon_sip3d);
-    b.SetBranch("Muon_isGlobal",          Muon_isGlobal);
-    b.SetBranch("Muon_isTracker",          Muon_isTracker);
-    b.SetBranch("Muon_isPFcand",          Muon_isPFcand);
-    b.SetBranch("Muon_tightCharge",       Muon_tightCharge);
-    
-    b.SetBranch("nJet",               nJet);
-    b.SetBranch("Jet_btagCSVV2",      Jet_btagCSVV2);
-    b.SetBranch("Jet_btagDeepB",      Jet_btagDeepB);
-    b.SetBranch("Jet_eta",            Jet_eta);
-    b.SetBranch("Jet_phi",            Jet_phi);
-    b.SetBranch("Jet_pt",             Jet_pt);
-    b.SetBranch("Jet_mass",           Jet_mass);
-    b.SetBranch("Jet_jetId",          Jet_jetId);
-    b.SetBranch("Jet_hadronFlavour",  Jet_hadronFlavour);
-    b.SetBranch("Jet_rawFactor",  Jet_rawFactor);
 
-    b.SetBranch("MET_pt",     MET);
-    b.SetBranch("MET_phi",    type1_pfMETPhi);
+    b.SetBranch("nMuon", nMuon);
+    b.SetBranch("Muon_pt", Muon_pt);
+    b.SetBranch("Muon_eta", Muon_eta);
+    b.SetBranch("Muon_phi", Muon_phi);
+    b.SetBranch("Muon_mass", Muon_mass);
+    b.SetBranch("Muon_charge", Muon_charge);
+    b.SetBranch("Muon_mediumId", Muon_mediumId);
+    b.SetBranch("Muon_miniPFRelIso_all", Muon_miniPFRelIso_all);
+    b.SetBranch("Muon_dxy", Muon_dxy);
+    b.SetBranch("Muon_dz", Muon_dz);
+    b.SetBranch("Muon_sip3d", Muon_sip3d);
+    b.SetBranch("Muon_isGlobal", Muon_isGlobal);
+    b.SetBranch("Muon_isTracker", Muon_isTracker);
+    b.SetBranch("Muon_isPFcand", Muon_isPFcand);
+    b.SetBranch("Muon_tightCharge", Muon_tightCharge);
+
+    b.SetBranch("nJet", nJet);
+    b.SetBranch("Jet_btagCSVV2", Jet_btagCSVV2);
+    b.SetBranch("Jet_btagDeepB", Jet_btagDeepB);
+    b.SetBranch("Jet_eta", Jet_eta);
+    b.SetBranch("Jet_phi", Jet_phi);
+    b.SetBranch("Jet_pt", Jet_pt);
+    b.SetBranch("Jet_mass", Jet_mass);
+    b.SetBranch("Jet_jetId", Jet_jetId);
+    b.SetBranch("Jet_hadronFlavour", Jet_hadronFlavour);
+    b.SetBranch("Jet_rawFactor", Jet_rawFactor);
+
+    b.SetBranch("MET_pt", MET);
+    b.SetBranch("MET_phi", type1_pfMETPhi);
 
     b.SetBranch("event", event);
     b.SetBranch("luminosityBlock", lumi);
 
-    if(applyScaleFactors_) {
-	b.SetBranch("GenPart_pdgId",GenPart_pdgId);
-	b.SetBranch("GenPart_genPartIdxMother", GenPart_genPartIdxMother);
-	b.SetBranch("GenPart_status", GenPart_status);
-	b.SetBranch("nGenPart", nGenPart);
+    if (applyScaleFactors_) {
+        b.SetBranch("GenPart_pdgId", GenPart_pdgId);
+        b.SetBranch("GenPart_genPartIdxMother", GenPart_genPartIdxMother);
+        b.SetBranch("GenPart_status", GenPart_status);
+        b.SetBranch("nGenPart", nGenPart);
     }
-    
+
     b.SetBranch("Flag_goodVertices", Flag_goodVertices);
-    b.SetBranch("Flag_globalSuperTightHalo2016Filter", Flag_globalSuperTightHalo2016Filter);
+    b.SetBranch("Flag_globalSuperTightHalo2016Filter",
+                Flag_globalSuperTightHalo2016Filter);
     b.SetBranch("Flag_HBHENoiseFilter", Flag_HBHENoiseFilter);
     b.SetBranch("Flag_HBHENoiseIsoFilter", Flag_HBHENoiseIsoFilter);
-    b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilter", Flag_EcalDeadCellTriggerPrimitiveFilter);
+    b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilter",
+                Flag_EcalDeadCellTriggerPrimitiveFilter);
     b.SetBranch("Flag_BadPFMuonFilter", Flag_BadPFMuonFilter);
     b.SetBranch("Flag_ecalBadCalibFilter", Flag_ecalBadCalibFilter);
 
 #ifdef CLOSEJET_REWEIGHT
     b.SetBranch("Jet_L1", Jet_L1);
     b.SetBranch("Jet_L2L3", Jet_L2L3);
-#endif // CLOSEJET_REWEIGHT
+#endif  // CLOSEJET_REWEIGHT
 
     if (isMC_) {
-	b.SetBranch("genWeight",    genWeight);
-	b.SetBranch("Pileup_nPU",   numPU);
-	b.SetBranch("Pileup_nTrueInt", Pileup_nTrueInt);
+        b.SetBranch("genWeight", genWeight);
+        b.SetBranch("Pileup_nPU", numPU);
+        b.SetBranch("Pileup_nTrueInt", Pileup_nTrueInt);
     }
 
-    mvaValues[CBID_LOOSE] = {{-0.46, -0.48, 0, -0.85}, 
-			     {-0.03, -0.67, 0, -0.91},
-			     {0.06, -0.49, 0, -0.83}};
-    mvaValues[CBID_TIGHT] = {{10, 0.77, 0, 0.52}, 
-			     {10, 0.56, 0, 0.11},
-			     {10, 0.48, 0, -0.01}};
+    mvaValues[CBID_LOOSE] = {{-0.46, -0.48, 0, -0.85},
+                             {-0.03, -0.67, 0, -0.91},
+                             {0.06, -0.49, 0, -0.83}};
+    mvaValues[CBID_TIGHT] = {
+        {10, 0.77, 0, 0.52}, {10, 0.56, 0, 0.11}, {10, 0.48, 0, -0.01}};
     /// Setup interpolation used for 25>pt>15
-    for(auto& pair: mvaValues) {
-	for(auto& vec: pair.second) {
-	    vec[2] = (vec[3]-vec[1])/10;
-	}
+    for (auto& pair : mvaValues) {
+        for (auto& vec : pair.second) {
+            vec[2] = (vec[3] - vec[1]) / 10;
+        }
     }
 }
 
@@ -196,28 +210,35 @@ void ThreeLepSelector::clearValues() {
     goodJets.clear();
 }
 
-void ThreeLepSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void ThreeLepSelector::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     clearValues();
 
     b.SetEntry(entry);
 
-    if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_ || nGenPart > N_KEEP_GEN_) {
-	std::string message = "Found more electrons or muons than max read number.\n    Found ";
-	message += std::to_string(nElectron);
-	message += " electrons.\n    Found ";
-	message += std::to_string(nMuon);
-	message += " Muons\n  --> Max read number was ";
-	message += std::to_string(N_KEEP_MU_E_);
-	message += "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ to avoid this error.\n";
-	message += std::to_string(nGenPart);
-	message += " Gens\n  --> Max read number was ";
-	message += std::to_string(N_KEEP_GEN_);
-	message += "\nExiting because this can cause problems. Increase N_KEEP_GEN_ to avoid this error.\n";
-	throw std::domain_error(message);
+    if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_ ||
+        nGenPart > N_KEEP_GEN_) {
+        std::string message =
+            "Found more electrons or muons than max read number.\n    Found ";
+        message += std::to_string(nElectron);
+        message += " electrons.\n    Found ";
+        message += std::to_string(nMuon);
+        message += " Muons\n  --> Max read number was ";
+        message += std::to_string(N_KEEP_MU_E_);
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ "
+            "to avoid this error.\n";
+        message += std::to_string(nGenPart);
+        message += " Gens\n  --> Max read number was ";
+        message += std::to_string(N_KEEP_GEN_);
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_GEN_ "
+            "to avoid this error.\n";
+        throw std::domain_error(message);
     }
 
-    if(eventVec[event]) return;
-    
+    if (eventVec[event]) return;
+
     /// basic setups
     setupElectrons();
     setupMuons();
@@ -225,308 +246,313 @@ void ThreeLepSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic,
     setupChannel();
 
     if (isMC_) {
-	ApplyScaleFactors();
+        ApplyScaleFactors();
     }
 
-    if(goodLeptons.size() >= 2 && looseLeptons.size() >= 3) {
-	for(auto lep : goodLeptons) {
-	    passZVeto = doesPassZVeto(lep, looseLeptons);
-	    if(!passZVeto) break;
-	}
+    if (goodLeptons.size() >= 2 && looseLeptons.size() >= 3) {
+        for (auto lep : goodLeptons) {
+            passZVeto = doesPassZVeto(lep, looseLeptons);
+            if (!passZVeto) break;
+        }
     }
 }
 
 void ThreeLepSelector::setupMuons() {
     for (size_t i = 0; i < nMuon; ++i) {
-	if(isGoodMuon(i)) {
-	    goodLeptons.push_back(GoodPart(get4Vector(PID_MUON, i), PID_MUON * Muon_charge[i]));
-	    goodLeptons.back().index = i;
-	    looseLeptons.push_back(goodLeptons.back());
-            
-	    if(!passFullIso(goodLeptons.back().v, 0.76, 7.2)) {    // Extra Iso requirement
-		goodLeptons.pop_back();
-	    }
-	}
-	else if(isLooseMuon(i)) {
-	    looseLeptons.push_back(GoodPart(get4Vector(PID_MUON, i), PID_MUON * Muon_charge[i]));
-	    looseLeptons.back().index = i;
-	}
-    }
+        if (isGoodMuon(i)) {
+            goodLeptons.push_back(
+                GoodPart(get4Vector(PID_MUON, i), PID_MUON * Muon_charge[i]));
+            goodLeptons.back().index = i;
+            looseLeptons.push_back(goodLeptons.back());
 
+            if (!passFullIso(goodLeptons.back().v, 0.76,
+                             7.2)) {  // Extra Iso requirement
+                goodLeptons.pop_back();
+            }
+        } else if (isLooseMuon(i)) {
+            looseLeptons.push_back(
+                GoodPart(get4Vector(PID_MUON, i), PID_MUON * Muon_charge[i]));
+            looseLeptons.back().index = i;
+        }
+    }
 }
 
 void ThreeLepSelector::setupElectrons() {
     for (size_t i = 0; i < nElectron; ++i) {
-	if( isGoodElectron(i)) {
-            goodLeptons.push_back(GoodPart(get4Vector(PID_ELECTRON, i), PID_ELECTRON * Electron_charge[i]));
-	    goodLeptons.back().index = i;
-	    looseLeptons.push_back(goodLeptons.back());
-            
-	    if(!passFullIso(goodLeptons.back().v, 0.8, 7.2)) {   // Extra Iso requirement
-	    	goodLeptons.pop_back();
-	    }
-	}
-	else if(isLooseElectron(i)) {
-	    looseLeptons.push_back(GoodPart(get4Vector(PID_ELECTRON, i), PID_ELECTRON * Electron_charge[i]));
-	    looseLeptons.back().index = i;
-	}
+        if (isGoodElectron(i)) {
+            goodLeptons.push_back(GoodPart(get4Vector(PID_ELECTRON, i),
+                                           PID_ELECTRON * Electron_charge[i]));
+            goodLeptons.back().index = i;
+            looseLeptons.push_back(goodLeptons.back());
+
+            if (!passFullIso(goodLeptons.back().v, 0.8,
+                             7.2)) {  // Extra Iso requirement
+                goodLeptons.pop_back();
+            }
+        } else if (isLooseElectron(i)) {
+            looseLeptons.push_back(GoodPart(get4Vector(PID_ELECTRON, i),
+                                            PID_ELECTRON * Electron_charge[i]));
+            looseLeptons.back().index = i;
+        }
     }
 }
 
 void ThreeLepSelector::setupJets() {
     std::vector<size_t> closeJet;
-    for(auto lep : looseLeptons) {
-    	if(passFakeableCuts(lep)) closeJet.push_back(getCloseJetIndex(lep.v, 0.4));
+    for (auto lep : looseLeptons) {
+        if (passFakeableCuts(lep))
+            closeJet.push_back(getCloseJetIndex(lep.v, 0.4));
     }
 
-    for(size_t i = 0; i < nJet; ++i) {
-	// if(goodLeptons.size() < 2) break;  // only try to find jets if have leptons
-	if(std::find(closeJet.begin(), closeJet.end(), i) != closeJet.end()) continue;
-	/// jet
-	bool passedGoodJet = false;
-	if(isGoodJet(i)) {
-	    passedGoodJet = true;
-	    goodJets.push_back(GoodPart(get4Vector(PID_JET, i), Jet_hadronFlavour[i]));
-	    goodJets.back().setPassJetSel();
-	    goodJets.back().index = i;
-	    nJets++;
-	    HT += Jet_pt[i];
-	}
-	// bjet
-	if(isGoodBJet(i)) {
-	    if(!passedGoodJet) {
-		goodJets.push_back(GoodPart(get4Vector(PID_BJET, i), Jet_hadronFlavour[i]));
-		goodJets.back().index = i;
-	    }
+    for (size_t i = 0; i < nJet; ++i) {
+        // if(goodLeptons.size() < 2) break;  // only try to find jets if have
+        // leptons
+        if (std::find(closeJet.begin(), closeJet.end(), i) != closeJet.end())
+            continue;
+        /// jet
+        bool passedGoodJet = false;
+        if (isGoodJet(i)) {
+            passedGoodJet = true;
+            goodJets.push_back(
+                GoodPart(get4Vector(PID_JET, i), Jet_hadronFlavour[i]));
+            goodJets.back().setPassJetSel();
+            goodJets.back().index = i;
+            nJets++;
+            HT += Jet_pt[i];
+        }
+        // bjet
+        if (isGoodBJet(i)) {
+            if (!passedGoodJet) {
+                goodJets.push_back(
+                    GoodPart(get4Vector(PID_BJET, i), Jet_hadronFlavour[i]));
+                goodJets.back().index = i;
+            }
             goodJets.back().setPassBJetSel();
-	    nBJets++;
-	}
+            nBJets++;
+        }
     }
-
 }
 
 void ThreeLepSelector::setupChannel() {
-    if(goodLeptons.size() > 2) {
-	channelName_ = "lll";
-	if(goodLeptons[1].Charge() * goodLeptons[2].Charge() > 0) {
-	    std::swap(goodLeptons[0], goodLeptons[2]);
-	}
-	else if(goodLeptons[0].Charge() * goodLeptons[2].Charge() > 0) {
-	    std::swap(goodLeptons[1], goodLeptons[2]);
-	}
-	/// PT swap
-	if(goodLeptons[0].Pt() < goodLeptons[1].Pt()) {
-	    std::swap(goodLeptons[0], goodLeptons[1]);
-	}
-    }
-    else if(goodLeptons.size() < 2) {
-	channelName_ = "Unknown";
-    }
-    else if(goodLeptons[0].Id() == PID_MUON && goodLeptons[1].Id() == PID_MUON) {
-	channelName_ = "mm";
-    }
-    else if(goodLeptons[0].Id() == PID_ELECTRON && goodLeptons[1].Id() == PID_ELECTRON) {
-	channelName_ = "ee";
-    }
-    else {
-	channelName_ = "em";
-	if(goodLeptons[0].Pt() < goodLeptons[1].Pt()) {
-	    std::swap(goodLeptons[0], goodLeptons[1]);
-	}
+    if (goodLeptons.size() > 2) {
+        channelName_ = "lll";
+        if (goodLeptons[1].Charge() * goodLeptons[2].Charge() > 0) {
+            std::swap(goodLeptons[0], goodLeptons[2]);
+        } else if (goodLeptons[0].Charge() * goodLeptons[2].Charge() > 0) {
+            std::swap(goodLeptons[1], goodLeptons[2]);
+        }
+        /// PT swap
+        if (goodLeptons[0].Pt() < goodLeptons[1].Pt()) {
+            std::swap(goodLeptons[0], goodLeptons[1]);
+        }
+    } else if (goodLeptons.size() < 2) {
+        channelName_ = "Unknown";
+    } else if (goodLeptons[0].Id() == PID_MUON &&
+               goodLeptons[1].Id() == PID_MUON) {
+        channelName_ = "mm";
+    } else if (goodLeptons[0].Id() == PID_ELECTRON &&
+               goodLeptons[1].Id() == PID_ELECTRON) {
+        channelName_ = "ee";
+    } else {
+        channelName_ = "em";
+        if (goodLeptons[0].Pt() < goodLeptons[1].Pt()) {
+            std::swap(goodLeptons[0], goodLeptons[1]);
+        }
     }
 
     channel_ = channelMap_[channelName_];
 }
 
-
 LorentzVector ThreeLepSelector::get4Vector(PID pid, int idx) {
-    if(pid == PID_MUON)
-	return LorentzVector(Muon_pt[idx], Muon_eta[idx], Muon_phi[idx], Muon_mass[idx]);
-    else if(pid == PID_ELECTRON)
-	return LorentzVector(Electron_pt[idx]/CHGPT(idx), Electron_eta[idx], Electron_phi[idx], Electron_mass[idx]);
+    if (pid == PID_MUON)
+        return LorentzVector(Muon_pt[idx], Muon_eta[idx], Muon_phi[idx],
+                             Muon_mass[idx]);
+    else if (pid == PID_ELECTRON)
+        return LorentzVector(Electron_pt[idx] / CHGPT(idx), Electron_eta[idx],
+                             Electron_phi[idx], Electron_mass[idx]);
     else
-	return LorentzVector(Jet_pt[idx], Jet_eta[idx], Jet_phi[idx], Jet_mass[idx]);
+        return LorentzVector(Jet_pt[idx], Jet_eta[idx], Jet_phi[idx],
+                             Jet_mass[idx]);
 }
 
-
-bool ThreeLepSelector::doesPassZVeto(GoodPart& lep, std::vector<GoodPart>& looseList) {
+bool ThreeLepSelector::doesPassZVeto(GoodPart& lep,
+                                     std::vector<GoodPart>& looseList) {
     for (auto lLep : looseList) {
-	if( lep.Charge() == -1*lLep.Charge() &&  //opposite charge, same ID
-	    (abs((lLep.v + lep.v).M() - 91.188) < 15 || (lLep.v + lep.v).M() < 12)) {
-	    return false;
-	}
+        if (lep.Charge() == -1 * lLep.Charge() &&  // opposite charge, same ID
+            (abs((lLep.v + lep.v).M() - 91.188) < 15 ||
+             (lLep.v + lep.v).M() < 12)) {
+            return false;
+        }
     }
     return true;
 }
 
 void ThreeLepSelector::ApplyScaleFactors() {
-    if(selection_ == BEfficiency) return;
+    if (selection_ == BEfficiency) return;
     // weight *= (genWeight > 0) ? 1 : -1;
     weight *= genWeight;
 
-    if(!applyScaleFactors_ || goodLeptons.size() < 2) return;
+    if (!applyScaleFactors_ || goodLeptons.size() < 2) return;
 
-    for(auto lep: goodLeptons) {
-	weight *= leptonScaleFactor(lep.Id(), lep.Pt(), lep.Eta(), HT);
+    for (auto lep : goodLeptons) {
+        weight *= leptonScaleFactor(lep.Id(), lep.Pt(), lep.Eta(), HT);
     }
-        
-    weight *= triggerScaleFactor(goodLeptons[0].Id(), goodLeptons[1].Id(),
-				 goodLeptons[0].Pt(), goodLeptons[1].Pt(),
-				 goodLeptons[0].Eta(), goodLeptons[1].Eta(), HT);
+
+    weight *= triggerScaleFactor(
+        goodLeptons[0].Id(), goodLeptons[1].Id(), goodLeptons[0].Pt(),
+        goodLeptons[1].Pt(), goodLeptons[0].Eta(), goodLeptons[1].Eta(), HT);
     weight *= getTruePUw_Moriond(Pileup_nTrueInt);
     weight *= getWDecayScaleFactor();
-    
-    for(auto jet : goodJets) {
-	BTagEntry::JetFlavor flav;
-	if(jet.Id() == PID_BJET) flav = BTagEntry::FLAV_B;
-	else if(jet.Id() == PID_CJET) flav = BTagEntry::FLAV_C;
-	else  flav = BTagEntry::FLAV_UDSG;
-	double bSF = btag_reader.eval_auto_bounds("central",  flav, jet.Eta(), jet.Pt());
-	if( jet.passedBJetSel() ) {
-	    weight *= bSF;
-	} else {
-	    double eff = getBtagEffFromFile(jet.Pt(), jet.Eta(), jet.Id());
-	    weight *= (1 - bSF * eff) / (1 - eff);
-	}
+
+    for (auto jet : goodJets) {
+        BTagEntry::JetFlavor flav;
+        if (jet.Id() == PID_BJET)
+            flav = BTagEntry::FLAV_B;
+        else if (jet.Id() == PID_CJET)
+            flav = BTagEntry::FLAV_C;
+        else
+            flav = BTagEntry::FLAV_UDSG;
+        double bSF =
+            btag_reader.eval_auto_bounds("central", flav, jet.Eta(), jet.Pt());
+        if (jet.passedBJetSel()) {
+            weight *= bSF;
+        } else {
+            double eff = getBtagEffFromFile(jet.Pt(), jet.Eta(), jet.Id());
+            weight *= (1 - bSF * eff) / (1 - eff);
+        }
     }
 
     return;
 }
 bool ThreeLepSelector::passFakeableCuts(GoodPart& lep) {
     int index = lep.index;
-    if(lep.Pt() < 10) return false;
-    if(lep.Id() == PID_MUON) {
-	return (Muon_mediumId[index] 
-		&& Muon_sip3d[index] < 4
-		&& Muon_tightCharge[index] == 2
-		&& passFullIso(lep.v, 0.72, 7.2)
-		
-		);
-    }
-    else {
-	return (Electron_sip3d[index] < 4
-		&& Electron_tightCharge[index] == 2
-		&& Electron_lostHits[index] == 0
-		&& passFullIso(lep.v, 0.8, 7.2)
-		);
+    if (lep.Pt() < 10) return false;
+    if (lep.Id() == PID_MUON) {
+        return (Muon_mediumId[index] && Muon_sip3d[index] < 4 &&
+                Muon_tightCharge[index] == 2 && passFullIso(lep.v, 0.72, 7.2)
+
+        );
+    } else {
+        return (Electron_sip3d[index] < 4 && Electron_tightCharge[index] == 2 &&
+                Electron_lostHits[index] == 0 && passFullIso(lep.v, 0.8, 7.2));
     }
 }
-
 
 bool ThreeLepSelector::isGoodMuon(size_t index) {
     bool yearCuts = true;
-    if(year_ == yr2016) yearCuts = (Muon_miniPFRelIso_all[index] < 0.16);
-    else                yearCuts = (Muon_miniPFRelIso_all[index] < 0.11);
-    
-    return ( (Muon_pt[index] > 20) 
-	     && (Muon_tightCharge[index] == 2) 
-	     && (abs(Muon_eta[index]) < 2.4) 
-	     && (Muon_mediumId[index]) 
-	     && (yearCuts) 
-	     && (abs(Muon_dz[index]) < 0.1) 
-	     && (abs(Muon_dxy[index]) < 0.05) 
-	     && (Muon_sip3d[index] < 4)
-	     );
+    if (year_ == yr2016)
+        yearCuts = (Muon_miniPFRelIso_all[index] < 0.16);
+    else
+        yearCuts = (Muon_miniPFRelIso_all[index] < 0.11);
+
+    return ((Muon_pt[index] > 20) && (Muon_tightCharge[index] == 2) &&
+            (abs(Muon_eta[index]) < 2.4) && (Muon_mediumId[index]) &&
+            (yearCuts) && (abs(Muon_dz[index]) < 0.1) &&
+            (abs(Muon_dxy[index]) < 0.05) && (Muon_sip3d[index] < 4));
 }
 
-bool ThreeLepSelector::passMVACut(std::vector<std::vector<double> > mvaCuts, int index) {
+bool ThreeLepSelector::passMVACut(std::vector<std::vector<double>> mvaCuts,
+                                  int index) {
     int caseIndex = 0;
     //// PT Splitting
-    if(Electron_pt[index]/CHGPT(index) < 5)       return false;
-    else if(Electron_pt[index]/CHGPT(index) < 10) caseIndex += 0;
-    else if(Electron_pt[index]/CHGPT(index) < 15) caseIndex += 1;
-    else if(Electron_pt[index]/CHGPT(index) < 25) caseIndex += 2;
-    else                             caseIndex += 3;
+    if (Electron_pt[index] / CHGPT(index) < 5)
+        return false;
+    else if (Electron_pt[index] / CHGPT(index) < 10)
+        caseIndex += 0;
+    else if (Electron_pt[index] / CHGPT(index) < 15)
+        caseIndex += 1;
+    else if (Electron_pt[index] / CHGPT(index) < 25)
+        caseIndex += 2;
+    else
+        caseIndex += 3;
     //// ETA Splitting
-    if(abs(Electron_eta[index]) < 0.8)        caseIndex += 0;
-    else if(abs(Electron_eta[index]) < 1.479) caseIndex += 4;
-    else if(abs(Electron_eta[index]) < 2.5)   caseIndex += 8;
+    if (abs(Electron_eta[index]) < 0.8)
+        caseIndex += 0;
+    else if (abs(Electron_eta[index]) < 1.479)
+        caseIndex += 4;
+    else if (abs(Electron_eta[index]) < 2.5)
+        caseIndex += 8;
 
-    if(caseIndex % 4 != 2) return Electron_MVA[index] > mvaCuts[caseIndex/4][caseIndex%4];
-    else                  return Electron_MVA[index] > mvaInterpolate(Electron_pt[index]/CHGPT(index), mvaCuts[caseIndex/4]);
+    if (caseIndex % 4 != 2)
+        return Electron_MVA[index] > mvaCuts[caseIndex / 4][caseIndex % 4];
+    else
+        return Electron_MVA[index] >
+               mvaInterpolate(Electron_pt[index] / CHGPT(index),
+                              mvaCuts[caseIndex / 4]);
 }
 
 double ThreeLepSelector::mvaInterpolate(double pt, std::vector<double> cuts) {
-    return cuts[1] + cuts[2]*(pt-15);
+    return cuts[1] + cuts[2] * (pt - 15);
 }
-
 
 bool ThreeLepSelector::isGoodElectron(size_t index) {
-    if(abs(Electron_eta[index]) > 2.5) return false;
+    if (abs(Electron_eta[index]) > 2.5) return false;
     bool passId = false;
-    
-    if(selection_ == FourTopMVAEl || selection_ != FourTopCutBasedEl) {
-	if(year_ == yr2016 || year_ == yrdefault) {
+
+    if (selection_ == FourTopMVAEl || selection_ != FourTopCutBasedEl) {
+        if (year_ == yr2016 || year_ == yrdefault) {
             passId = passMVACut(mvaValues[CBID_TIGHT], index);
-	    passId = passId && (Electron_miniPFRelIso_all[index] < 0.12);
-	}
-	else if(year_ == yr2017) {
-	    ///// NEED to fix mva values for 2017
-	    passId = passMVACut(mvaValues[CBID_TIGHT], index);
-	    passId = passId && (Electron_miniPFRelIso_all[index] < 0.07);
-	}
+            passId = passId && (Electron_miniPFRelIso_all[index] < 0.12);
+        } else if (year_ == yr2017) {
+            ///// NEED to fix mva values for 2017
+            passId = passMVACut(mvaValues[CBID_TIGHT], index);
+            passId = passId && (Electron_miniPFRelIso_all[index] < 0.07);
+        }
     } else {
-	passId = (Electron_cutBased[index] >= CBID_MEDIUM);
-	//	if(year_ == yr2016)       passId = passId && (Electron_miniPFRelIso_all[index] < 0.12);
-	//	else if(year_ == yr2017)       passId = passId && (Electron_miniPFRelIso_all[index] < 0.07);
+        passId = (Electron_cutBased[index] >= CBID_MEDIUM);
+        //	if(year_ == yr2016)       passId = passId &&
+        //(Electron_miniPFRelIso_all[index] < 0.12); 	else if(year_ == yr2017)
+        //passId = passId && (Electron_miniPFRelIso_all[index] < 0.07);
     }
 
-    return ((Electron_pt[index]/CHGPT(index) > 20)
-	    && (passId)
-	    && (Electron_convVeto[index]) 
-	    && (Electron_lostHits[index] == 0) 
-	    && (Electron_tightCharge[index] == 2) 
-	    && (abs(Electron_dz[index]) < 0.1) 
-	    && (abs(Electron_dxy[index]) < 0.05) 
-	    && (Electron_sip3d[index] < 4)
-	    && passTriggerEmu(index)
-	    && Electron_dr03EcalRecHitSumEt[index] / Electron_pt[index]*CHGPT(index) < 0.45 
-	    && Electron_dr03HcalDepth1TowerSumEt[index] / Electron_pt[index]*CHGPT(index) < 0.25 
-	    && Electron_dr03TkSumPt[index] / Electron_pt[index]*CHGPT(index) < 0.2 
-	    );
+    return (
+        (Electron_pt[index] / CHGPT(index) > 20) && (passId) &&
+        (Electron_convVeto[index]) && (Electron_lostHits[index] == 0) &&
+        (Electron_tightCharge[index] == 2) && (abs(Electron_dz[index]) < 0.1) &&
+        (abs(Electron_dxy[index]) < 0.05) && (Electron_sip3d[index] < 4) &&
+        passTriggerEmu(index) &&
+        Electron_dr03EcalRecHitSumEt[index] / Electron_pt[index] *
+                CHGPT(index) <
+            0.45 &&
+        Electron_dr03HcalDepth1TowerSumEt[index] / Electron_pt[index] *
+                CHGPT(index) <
+            0.25 &&
+        Electron_dr03TkSumPt[index] / Electron_pt[index] * CHGPT(index) < 0.2);
 }
 
-
 bool ThreeLepSelector::isLooseMuon(size_t index) {
-    return ((Muon_isGlobal[index] || Muon_isTracker[index])
-	    && (Muon_isPFcand[index])
-	    && (Muon_miniPFRelIso_all[index] < 0.4)
-	    && (abs(Muon_dz[index]) < 0.1)
-	    && (abs(Muon_dxy[index]) < 0.05)
-	    && (Muon_pt[index] > 5)
-	    );
+    return ((Muon_isGlobal[index] || Muon_isTracker[index]) &&
+            (Muon_isPFcand[index]) && (Muon_miniPFRelIso_all[index] < 0.4) &&
+            (abs(Muon_dz[index]) < 0.1) && (abs(Muon_dxy[index]) < 0.05) &&
+            (Muon_pt[index] > 5));
 }
 
 bool ThreeLepSelector::isLooseElectron(size_t index) {
     bool passId = false;
 
-    if(selection_ == FourTopMVAEl || selection_ != FourTopCutBasedEl) {
-	passId = passMVACut(mvaValues[CBID_LOOSE], index);
+    if (selection_ == FourTopMVAEl || selection_ != FourTopCutBasedEl) {
+        passId = passMVACut(mvaValues[CBID_LOOSE], index);
+    } else {
+        passId = (Electron_cutBased[index] >= CBID_LOOSE);
     }
-    else {
-	passId = (Electron_cutBased[index] >= CBID_LOOSE);
-    }
-    return ((passId)//
-	    && (Electron_pt[index]/CHGPT(index) > 7)
-	    && (Electron_convVeto[index]) 
-	    && (Electron_lostHits[index] <= 1)
-	    && (Electron_miniPFRelIso_all[index] < 0.4) 
-	    && passTriggerEmu(index)
-	    && (abs(Electron_dz[index]) < 0.1) 
-	    && (abs(Electron_dxy[index]) < 0.05)
-	    );
+    return ((passId)  //
+            && (Electron_pt[index] / CHGPT(index) > 7) &&
+            (Electron_convVeto[index]) && (Electron_lostHits[index] <= 1) &&
+            (Electron_miniPFRelIso_all[index] < 0.4) && passTriggerEmu(index) &&
+            (abs(Electron_dz[index]) < 0.1) &&
+            (abs(Electron_dxy[index]) < 0.05));
 }
 
 bool ThreeLepSelector::isGoodJet(size_t index) {
     bool yearCut = true;
     double ptCut = 40;
-    
-    if(year_ == yr2016) yearCut = IntBits(Jet_jetId[index]).test(0);
-    else                yearCut = IntBits(Jet_jetId[index]).test(1);
-    return ((Jet_pt[index] > ptCut)      &&
-	    (abs(Jet_eta[index]) < 2.4) &&
-	    (yearCut)
-	    );
+
+    if (year_ == yr2016)
+        yearCut = IntBits(Jet_jetId[index]).test(0);
+    else
+        yearCut = IntBits(Jet_jetId[index]).test(1);
+    return ((Jet_pt[index] > ptCut) && (abs(Jet_eta[index]) < 2.4) &&
+            (yearCut));
 }
 
 /// TODO: add toggle for different btag stuff
@@ -534,45 +560,49 @@ bool ThreeLepSelector::isGoodJet(size_t index) {
 bool ThreeLepSelector::isGoodBJet(size_t index) {
     bool yearCut = true;
     double ptCut = 25;
-    
-    if(year_ == yr2016) yearCut = (IntBits(Jet_jetId[index]).test(0)) && (Jet_btagDeepB[index] > 0.6324);
-    else                yearCut = (IntBits(Jet_jetId[index]).test(1)) && (Jet_btagDeepB[index] > 0.4941);
 
-    return ((Jet_pt[index] > ptCut)
-	    && (abs(Jet_eta[index]) < 2.4)
-	    && (yearCut)
-	    );
+    if (year_ == yr2016)
+        yearCut = (IntBits(Jet_jetId[index]).test(0)) &&
+                  (Jet_btagDeepB[index] > 0.6324);
+    else
+        yearCut = (IntBits(Jet_jetId[index]).test(1)) &&
+                  (Jet_btagDeepB[index] > 0.4941);
+
+    return ((Jet_pt[index] > ptCut) && (abs(Jet_eta[index]) < 2.4) &&
+            (yearCut));
 }
 
-size_t ThreeLepSelector::getCloseJetIndex(LorentzVector& lep, double minDR ) {
+size_t ThreeLepSelector::getCloseJetIndex(LorentzVector& lep, double minDR) {
     size_t minIndex = -1;
-    
-    for(size_t index = 0; index < nJet; ++index) {
-	LorentzVector jet = get4Vector(PID_JET, index);
-	double dr = reco::deltaR(jet, lep);
-	if(minDR > dr) {
-	    minDR = dr;
-	    minIndex = index;
-	}
+
+    for (size_t index = 0; index < nJet; ++index) {
+        LorentzVector jet = get4Vector(PID_JET, index);
+        double dr = reco::deltaR(jet, lep);
+        if (minDR > dr) {
+            minDR = dr;
+            minIndex = index;
+        }
     }
     return minIndex;
 }
 
 bool ThreeLepSelector::passFullIso(LorentzVector& lep, double I2, double I3) {
     int closeIdx = getCloseJetIndex(lep);
-    LorentzVector closeJet  = get4Vector(PID_JET, closeIdx);
+    LorentzVector closeJet = get4Vector(PID_JET, closeIdx);
 #ifdef CLOSEJET_REWEIGHT
-    closeJet = (Jet_L1[closeIdx]*(1-Jet_rawFactor[closeIdx])*closeJet-lep)*Jet_L2L3[closeIdx]+lep;
-#endif // CLOSEJET_REWEIGHT
+    closeJet =
+        (Jet_L1[closeIdx] * (1 - Jet_rawFactor[closeIdx]) * closeJet - lep) *
+            Jet_L2L3[closeIdx] +
+        lep;
+#endif  // CLOSEJET_REWEIGHT
 
-    return (lep.Pt()/closeJet.Pt() > I2) || (LepRelPt(lep, closeJet) > I3);
+    return (lep.Pt() / closeJet.Pt() > I2) || (LepRelPt(lep, closeJet) > I3);
 }
-
 
 double ThreeLepSelector::LepRelPt(LorentzVector& lep, LorentzVector& closeJet) {
     auto diff = closeJet.Vect() - lep.Vect();
     auto cross = diff.Cross(lep.Vect());
-    return std::sqrt(cross.Mag2()/diff.Mag2());
+    return std::sqrt(cross.Mag2() / diff.Mag2());
 }
 
 // Need to include DeltaPhi Ieta
@@ -581,78 +611,75 @@ bool ThreeLepSelector::passTriggerEmu(size_t index) {
     int DEtaInCut = READFROM(Electron_vidBitmap[index], 6, 3);
     int DPhiInCut = READFROM(Electron_vidBitmap[index], 9, 3);
 
-    if(abs(Electron_eta[index]) < 1.479) {
-	etaDepend = Electron_sieie[index] < 0.011 && (DEtaInCut >= 1) && (DPhiInCut >= 4);
+    if (abs(Electron_eta[index]) < 1.479) {
+        etaDepend = Electron_sieie[index] < 0.011 && (DEtaInCut >= 1) &&
+                    (DPhiInCut >= 4);
+    } else {
+        etaDepend = Electron_sieie[index] < 0.031 && (DEtaInCut >= 1) &&
+                    (DPhiInCut >= 3);
     }
-    else {
-	etaDepend = Electron_sieie[index] < 0.031 && (DEtaInCut >= 1) && (DPhiInCut >= 3);
-    }
-    return (abs(Electron_eInvMinusPInv[index]) < 0.01 &&
-	    etaDepend &&
-	    Electron_hoe[index] < 0.08
-	    );
+    return (abs(Electron_eInvMinusPInv[index]) < 0.01 && etaDepend &&
+            Electron_hoe[index] < 0.08);
 }
-
 
 bool ThreeLepSelector::doesNotOverlap(size_t index) {
     LorentzVector tmp = get4Vector(PID_JET, index);
     double dR = 0.4;
-    for(auto lep: goodLeptons) {
-	if(reco::deltaR(tmp, lep.v) < dR) return false;
+    for (auto lep : goodLeptons) {
+        if (reco::deltaR(tmp, lep.v) < dR) return false;
     }
     return true;
 }
 
 bool ThreeLepSelector::MetFilter() {
-    return Flag_goodVertices
-	&& Flag_globalSuperTightHalo2016Filter
-	&& Flag_HBHENoiseFilter
-	&& Flag_HBHENoiseIsoFilter
-	&& Flag_EcalDeadCellTriggerPrimitiveFilter
-	&& Flag_BadPFMuonFilter
-	&& Flag_ecalBadCalibFilter;
+    return Flag_goodVertices && Flag_globalSuperTightHalo2016Filter &&
+           Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter &&
+           Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter &&
+           Flag_ecalBadCalibFilter;
 }
 
-void ThreeLepSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void ThreeLepSelector::FillHistograms(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     int step = 0;
     Fill1D("CutFlow", 0);
 
     /// Trigger
-    if(((channel_ == mm && !HLT_DoubleMu8_Mass8_PFHT300) ||
-	(channel_ == em && !HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300) ||
-	(channel_ == ee && !HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300))
-       && !HLT_AK8PFJet450 && !HLT_PFJet450
-       ) return;
+    if (((channel_ == mm && !HLT_DoubleMu8_Mass8_PFHT300) ||
+         (channel_ == em && !HLT_Mu8_Ele8_CaloIdM_TrackIdM_Mass8_PFHT300) ||
+         (channel_ == ee && !HLT_DoubleEle8_CaloIdM_TrackIdM_Mass8_PFHT300)) &&
+        !HLT_AK8PFJet450 && !HLT_PFJet450)
+        return;
     Fill1D("CutFlow", ++step);
 
-    if(!MetFilter()) return;
+    if (!MetFilter()) return;
     Fill1D("CutFlow", ++step);
 
     /// 2 good leptons
-    if(goodLeptons.size() < 2) return;
+    if (goodLeptons.size() < 2) return;
     Fill1D("CutFlow", ++step);
 
     // first lep requirement
-    if(goodLeptons[0].Pt() < 25) return;
+    if (goodLeptons[0].Pt() < 25) return;
     Fill1D("CutFlow", ++step);
 
     // same sign requirement
-    if((goodLeptons.size() == 2 && goodLeptons[0].Charge() * goodLeptons[1].Charge() < 0)
-       || (goodLeptons.size() == 3 && goodLeptons[0].Charge() * goodLeptons[2].Charge() > 0)
-       )
-	return;
+    if ((goodLeptons.size() == 2 &&
+         goodLeptons[0].Charge() * goodLeptons[1].Charge() < 0) ||
+        (goodLeptons.size() == 3 &&
+         goodLeptons[0].Charge() * goodLeptons[2].Charge() > 0))
+        return;
     Fill1D("CutFlow", ++step);
 
     // jet cut
-    if(nJets < 2) return;
+    if (nJets < 2) return;
     Fill1D("CutFlow", ++step);
 
     // bjet cut
-    if(nBJets < 2) return;
+    if (nBJets < 2) return;
     Fill1D("CutFlow", ++step);
 
     // ht cut
-    if(HT < 300) return;
+    if (HT < 300) return;
     Fill1D("CutFlow", ++step);
 
     // met cut
@@ -661,27 +688,25 @@ void ThreeLepSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std:
 
     Fill1D("SR", getSRBin());
 
-    if(getSRBin() == -1) {
-	return;
-    }
-    else if(getSRBin() == 0) {
-	Fill1D("CRW_Met", MET);
-	Fill1D("CRW_HT", HT);
-	Fill1D("CRW_njet", nJets);
-	Fill1D("CRW_nbjet", nBJets);
-	return;
-    }
-    else if(getSRBin() == 9) {
-	Fill1D("CRZ_Met", MET);
-	Fill1D("CRZ_HT", HT);
-    	Fill1D("CRZ_njet", nJets);
-	Fill1D("CRZ_nbjet", nBJets);
-	Fill1D("CRZ_ptl3", goodLeptons[3].Pt());
-	return;
+    if (getSRBin() == -1) {
+        return;
+    } else if (getSRBin() == 0) {
+        Fill1D("CRW_Met", MET);
+        Fill1D("CRW_HT", HT);
+        Fill1D("CRW_njet", nJets);
+        Fill1D("CRW_nbjet", nBJets);
+        return;
+    } else if (getSRBin() == 9) {
+        Fill1D("CRZ_Met", MET);
+        Fill1D("CRZ_HT", HT);
+        Fill1D("CRZ_njet", nJets);
+        Fill1D("CRZ_nbjet", nBJets);
+        Fill1D("CRZ_ptl3", goodLeptons[3].Pt());
+        return;
     }
 
     Fill1D("CutFlow", ++step);
-    
+
     HistFullFill(histMap1D_, "weight", variation.first, abs(weight), 1);
     Fill1D("Met", MET);
     Fill1D("HT", HT);
@@ -693,9 +718,7 @@ void ThreeLepSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std:
     Fill1D("nleps", goodLeptons.size());
 
     Fill1D("sphericity", JetSphericity(goodJets));
-    Fill1D("centrality", JetCentrality(goodJets,HT));
-    
-    
+    Fill1D("centrality", JetCentrality(goodJets, HT));
 }
 
 void ThreeLepSelector::SetupNewDirectory() {
@@ -705,67 +728,78 @@ void ThreeLepSelector::SetupNewDirectory() {
 }
 
 int ThreeLepSelector::getSRBin() const {
-    if(goodLeptons.size() == 2) {
-	if(nBJets == 2) {
-	    if(!passZVeto)      return -1;
-	    else if(nJets <= 5)   return 0;  // WCR
-	    else if(nJets == 6)  return 1;
-	    else if(nJets == 7)  return 2;
-	    else if(nJets >= 8)   return 3;
-	}
-	else if(nBJets == 3) {
-	    if(nJets == 5)       return 4;
-	    else if(nJets == 6)  return 4;
-	    else if(nJets >= 7)   return 5;
-	}
-	else if(nBJets >= 4) {
-	    if(nJets >= 5)         return 6;
-	}
+    if (goodLeptons.size() == 2) {
+        if (nBJets == 2) {
+            if (!passZVeto)
+                return -1;
+            else if (nJets <= 5)
+                return 0;  // WCR
+            else if (nJets == 6)
+                return 1;
+            else if (nJets == 7)
+                return 2;
+            else if (nJets >= 8)
+                return 3;
+        } else if (nBJets == 3) {
+            if (nJets == 5)
+                return 4;
+            else if (nJets == 6)
+                return 4;
+            else if (nJets >= 7)
+                return 5;
+        } else if (nBJets >= 4) {
+            if (nJets >= 5) return 6;
+        }
     } else {
-	if(!passZVeto)                     return 9;  /// ZCR
-	else if(nBJets == 2 && nJets >= 5)   return 7;
-	else if(nBJets >= 3 && nJets >= 4)    return 8;
+        if (!passZVeto)
+            return 9;  /// ZCR
+        else if (nBJets == 2 && nJets >= 5)
+            return 7;
+        else if (nBJets >= 3 && nJets >= 4)
+            return 8;
     }
 
     return -1;
 }
 
-float ThreeLepSelector::getBtagEffFromFile(double pt, double eta, int mcFlavour){
-    float pt_cutoff = std::max(20.,std::min(399.,pt));
+float ThreeLepSelector::getBtagEffFromFile(double pt, double eta,
+                                           int mcFlavour) {
+    float pt_cutoff = std::max(20., std::min(399., pt));
     if (abs(mcFlavour) == 5) {
-	// use pt bins up to 600 GeV for b
-	pt_cutoff = std::max(20.,std::min(599.,pt));
-	return h_btag_eff_b->GetBinContent(h_btag_eff_b->FindBin(pt_cutoff, fabs(eta)));
-    }
-    else if (abs(mcFlavour) == 4) {
-	return h_btag_eff_c->GetBinContent(h_btag_eff_c->FindBin(pt_cutoff, fabs(eta)));
-    }
-    else {
-	return h_btag_eff_udsg->GetBinContent(h_btag_eff_udsg->FindBin(pt_cutoff, fabs(eta)));
+        // use pt bins up to 600 GeV for b
+        pt_cutoff = std::max(20., std::min(599., pt));
+        return h_btag_eff_b->GetBinContent(
+            h_btag_eff_b->FindBin(pt_cutoff, fabs(eta)));
+    } else if (abs(mcFlavour) == 4) {
+        return h_btag_eff_c->GetBinContent(
+            h_btag_eff_c->FindBin(pt_cutoff, fabs(eta)));
+    } else {
+        return h_btag_eff_udsg->GetBinContent(
+            h_btag_eff_udsg->FindBin(pt_cutoff, fabs(eta)));
     }
 }
 
 double ThreeLepSelector::getWDecayScaleFactor() {
     float pdgleptW = 0.3258;
-    float genleptW = 1.0/3;
+    float genleptW = 1.0 / 3;
     int nleptonicW = 0;
     int nW = 0;
-    
-    for(size_t i=0; i < nGenPart; i++) {
-    	if(abs(GenPart_pdgId[i]) == 24
-    	   && (GenPart_status[i] == 22 || GenPart_status[i] == 52)
-    	   && abs(GenPart_pdgId[GenPart_genPartIdxMother[i]]) != 24) {
-    	    nW++;
-    	}
-    	else if((abs(GenPart_pdgId[i]) == 12
-    		 || abs(GenPart_pdgId[i]) == 14
-    		 || abs(GenPart_pdgId[i]) == 16)
-    		&& abs(GenPart_pdgId[GenPart_genPartIdxMother[i]]) == 24) {
-    	    nleptonicW++;
-    	}
-    	else continue;
+
+    for (size_t i = 0; i < nGenPart; i++) {
+        if (abs(GenPart_pdgId[i]) == 24 &&
+            (GenPart_status[i] == 22 || GenPart_status[i] == 52) &&
+            abs(GenPart_pdgId[GenPart_genPartIdxMother[i]]) != 24) {
+            nW++;
+        } else if ((abs(GenPart_pdgId[i]) == 12 ||
+                    abs(GenPart_pdgId[i]) == 14 ||
+                    abs(GenPart_pdgId[i]) == 16) &&
+                   abs(GenPart_pdgId[GenPart_genPartIdxMother[i]]) == 24) {
+            nleptonicW++;
+        } else
+            continue;
     }
 
     int nhadronicW = nW - nleptonicW;
-    return pow((pdgleptW/genleptW),nleptonicW) * pow(((1-pdgleptW)/(1-genleptW)),nhadronicW);
+    return pow((pdgleptW / genleptW), nleptonicW) *
+           pow(((1 - pdgleptW) / (1 - genleptW)), nhadronicW);
 }

--- a/src/WGenSelector.cc
+++ b/src/WGenSelector.cc
@@ -1,19 +1,43 @@
 #include "Analysis/VVAnalysis/interface/WGenSelector.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
-#include <TStyle.h>
-#include <regex>
-#include <cmath>
 #include <TRandom3.h>
+#include <TStyle.h>
+#include <cmath>
+#include <regex>
+#include "DataFormats/Math/interface/LorentzVector.h"
 
-void WGenSelector::Init(TTree *tree)
-{
+void WGenSelector::Init(TTree* tree) {
     histMap1D_[{"CutFlow", Unknown, Central}] = {};
     allChannels_ = {{ep, "ep"}, {en, "en"}, {mp, "mp"}, {mn, "mn"}};
-    hists1D_ = {"CutFlow", "mWmet", "yWmet", "ptWmet", "mW", "yW", "ptW", "mTtrue", "mTmet",
-        "ptl", "etal", "phil", "ptnu", "etanu", "phinu", "MET", "MET_phi",
-        "ptj1", "ptj2", "etaj1", "etaj2", "nJets",
-        "dRlgamma_maxptassoc", "dRlgamma_minassoc", "ptg_closeassoc", "ptg_maxassoc", "nGammaAssoc", 
-        "ptgmax_assoc", "ptgmax_assoc",
+    hists1D_ = {
+        "CutFlow",
+        "mWmet",
+        "yWmet",
+        "ptWmet",
+        "mW",
+        "yW",
+        "ptW",
+        "mTtrue",
+        "mTmet",
+        "ptl",
+        "etal",
+        "phil",
+        "ptnu",
+        "etanu",
+        "phinu",
+        "MET",
+        "MET_phi",
+        "ptj1",
+        "ptj2",
+        "etaj1",
+        "etaj2",
+        "nJets",
+        "dRlgamma_maxptassoc",
+        "dRlgamma_minassoc",
+        "ptg_closeassoc",
+        "ptg_maxassoc",
+        "nGammaAssoc",
+        "ptgmax_assoc",
+        "ptgmax_assoc",
         "ptl_smear",
     };
     hists2D_ = {"etal_ptl_2D", "etal_ptl_smear_2D"};
@@ -38,24 +62,25 @@ void WGenSelector::Init(TTree *tree)
     systHists_ = hists1D_;
     systHists2D_ = hists2D_;
 
-    weighthists1D_ = {"CutFlow", "mW", "mTmet", "yW", "ptW", "ptl", "ptl_smear", "etal", "ptnu", "etanu", };
+    weighthists1D_ = {
+        "CutFlow", "mW",        "mTmet", "yW",   "ptW",
+        "ptl",     "ptl_smear", "etal",  "ptnu", "etanu",
+    };
     weighthists2D_ = hists2D_;
 
     refWeight = 1;
     nLeptons_ = 1;
     doNeutrinos_ = true;
     doPhotons_ = true;
-    
+
     // Chose by MC sample
     if (name_.find("nnlops") != std::string::npos) {
         MV_GEN_ = 80398.0;
         GAMMAV_GEN_ = 2088.720;
-    }
-    else if (name_.find("minnlo") != std::string::npos) {
+    } else if (name_.find("minnlo") != std::string::npos) {
         MV_GEN_ = 80351.97159;
         GAMMAV_GEN_ = 2084.29889;
-    }
-    else {
+    } else {
         MV_GEN_ = 80419.;
         GAMMAV_GEN_ = 2050;
     }
@@ -63,21 +88,25 @@ void WGenSelector::Init(TTree *tree)
     NanoGenSelectorBase::Init(tree);
 }
 
-void WGenSelector::LoadBranchesNanoAOD(Long64_t entry, SystPair variation) { 
+void WGenSelector::LoadBranchesNanoAOD(Long64_t entry, SystPair variation) {
     NanoGenSelectorBase::LoadBranchesNanoAOD(entry, variation);
 
     if (leptons.size() >= nLeptons_) {
         auto& l = leptons.at(0);
         if (variation.first == Central) {
             TRandom3 gauss;
-            ptl_smear = l.pt()*gauss.Gaus(1, 0.01);
-        }
-        else if (variation.first == muonScaleUp) {
-            leptons.at(0).setP4(makeGenParticle(l.pdgId(), l.status(), l.pt()*1.001, l.eta(), l.phi(), l.mass()).polarP4());
+            ptl_smear = l.pt() * gauss.Gaus(1, 0.01);
+        } else if (variation.first == muonScaleUp) {
+            leptons.at(0).setP4(makeGenParticle(l.pdgId(), l.status(),
+                                                l.pt() * 1.001, l.eta(),
+                                                l.phi(), l.mass())
+                                    .polarP4());
             SetComposite();
-        }
-        else if (variation.first == muonScaleDown) {
-            leptons.at(0).setP4(makeGenParticle(l.pdgId(), l.status(), l.pt()*1./1.001, l.eta(), l.phi(), l.mass()).polarP4());
+        } else if (variation.first == muonScaleDown) {
+            leptons.at(0).setP4(makeGenParticle(l.pdgId(), l.status(),
+                                                l.pt() * 1. / 1.001, l.eta(),
+                                                l.phi(), l.mass())
+                                    .polarP4());
             SetComposite();
         }
     }
@@ -86,50 +115,45 @@ void WGenSelector::LoadBranchesNanoAOD(Long64_t entry, SystPair variation) {
         cenWeight = weight;
     else if (variation.first == LHEParticles) {
         ptVlhe = wCand.pt();
-        mVlhe = wCand.mass()*1000.;
-    }
-    else if (variation.first == mWShift10MeVUp)
-        weight = cenWeight*breitWignerWeight(10.);
+        mVlhe = wCand.mass() * 1000.;
+    } else if (variation.first == mWShift10MeVUp)
+        weight = cenWeight * breitWignerWeight(10.);
     else if (variation.first == mWShift10MeVDown)
-        weight = cenWeight*breitWignerWeight(-10.);
+        weight = cenWeight * breitWignerWeight(-10.);
     else if (variation.first == mWShift20MeVUp)
-        weight = cenWeight*breitWignerWeight(20.);
+        weight = cenWeight * breitWignerWeight(20.);
     else if (variation.first == mWShift20MeVDown)
-        weight = cenWeight*breitWignerWeight(-20.);
+        weight = cenWeight * breitWignerWeight(-20.);
     else if (variation.first == mWShift25MeVUp)
-        weight = cenWeight*breitWignerWeight(25.);
+        weight = cenWeight * breitWignerWeight(25.);
     else if (variation.first == mWShift25MeVDown)
-        weight = cenWeight*breitWignerWeight(-25.);
+        weight = cenWeight * breitWignerWeight(-25.);
     else if (variation.first == mWShift50MeVUp)
-        weight = cenWeight*breitWignerWeight(50.);
+        weight = cenWeight * breitWignerWeight(50.);
     else if (variation.first == mWShift50MeVDown)
-        weight = cenWeight*breitWignerWeight(-50.);
+        weight = cenWeight * breitWignerWeight(-50.);
     else if (variation.first == mWShift100MeVUp)
-        weight = cenWeight*breitWignerWeight(100.);
+        weight = cenWeight * breitWignerWeight(100.);
     else if (variation.first == mWShift100MeVDown)
-        weight = cenWeight*breitWignerWeight(-100.);
+        weight = cenWeight * breitWignerWeight(-100.);
 
     if (leptons.size() > 0 && std::abs(leptons.at(0).pdgId()) == 11) {
         if (leptons.at(0).pdgId() > 0) {
             channel_ = en;
             channelName_ = "en";
-        }
-        else {
+        } else {
             channel_ = ep;
             channelName_ = "ep";
         }
-    }
-    else if (leptons.size() > 0 && std::abs(leptons.at(0).pdgId()) == 13) {
+    } else if (leptons.size() > 0 && std::abs(leptons.at(0).pdgId()) == 13) {
         if (leptons.at(0).pdgId() > 0) {
             channel_ = mn;
             channelName_ = "mn";
-        }
-        else {
+        } else {
             channel_ = mp;
             channelName_ = "mp";
         }
-    }
-    else {
+    } else {
         channel_ = Unknown;
         channelName_ = "Unknown";
         return;
@@ -141,18 +165,21 @@ void WGenSelector::SetComposite() {
         wCandMet = LorentzVector();
         wCand = LorentzVector();
         return;
-    }
-    else if (neutrinos.size() == 0) {
+    } else if (neutrinos.size() == 0) {
         wCand = LorentzVector();
         return;
     }
     auto lepP4 = leptons.at(0).polarP4();
-    auto compareByPt = [](const reco::GenParticle& a, const reco::GenParticle& b) { return a.pt() < b.pt(); };
-    auto mt = [] (LorentzVector& l, LorentzVector& v) {
-        return std::sqrt(2*l.pt()*v.pt()*(1 - cos(l.phi() - v.phi())));
+    auto compareByPt = [](const reco::GenParticle& a,
+                          const reco::GenParticle& b) {
+        return a.pt() < b.pt();
+    };
+    auto mt = [](LorentzVector& l, LorentzVector& v) {
+        return std::sqrt(2 * l.pt() * v.pt() * (1 - cos(l.phi() - v.phi())));
     };
 
-    auto nup = std::max_element(neutrinos.begin(), neutrinos.end(), compareByPt);
+    auto nup =
+        std::max_element(neutrinos.begin(), neutrinos.end(), compareByPt);
     if (neutrinos.size()) {
         nu = neutrinos.size() > 0 ? nup->polarP4() : LorentzVector();
         wCandMet = lepP4 + genMet;
@@ -162,37 +189,39 @@ void WGenSelector::SetComposite() {
     mTmet = mt(lepP4, genMet);
 }
 
-void WGenSelector::FillHistograms(Long64_t entry, SystPair variation) { 
+void WGenSelector::FillHistograms(Long64_t entry, SystPair variation) {
     std::string lepType = "";
     FillHistogramsByName(entry, lepType, variation);
 }
 
-void WGenSelector::FillHistogramsByName(Long64_t entry, std::string& toAppend, SystPair variation) { 
+void WGenSelector::FillHistogramsByName(Long64_t entry, std::string& toAppend,
+                                        SystPair variation) {
     int step = 0;
-    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_, variation.first, step++, weight);
+    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_,
+                 variation.first, step++, weight);
 
-    if (channel_ != mn && channel_ != en && channel_ != mp && channel_ != ep) 
+    if (channel_ != mn && channel_ != en && channel_ != mp && channel_ != ep)
         return;
-    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_, variation.first, step++, weight);
+    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_,
+                 variation.first, step++, weight);
 
-    if (leptons.size() < nLeptons_)
-        return;
-    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_, variation.first, step++, weight);
+    if (leptons.size() < nLeptons_) return;
+    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_,
+                 variation.first, step++, weight);
 
-    if (neutrinos.size() < nLeptons_)
-        return;
-    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_, variation.first, step++, weight);
+    if (neutrinos.size() < nLeptons_) return;
+    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_,
+                 variation.first, step++, weight);
 
     auto& lep = leptons.at(0);
-    if (doFiducial_ && std::abs(lep.eta()) > 2.5)
-        return;
-    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_, variation.first, step++, weight);
+    if (doFiducial_ && std::abs(lep.eta()) > 2.5) return;
+    SafeHistFill(histMap1D_, concatenateNames("CutFlow", toAppend), channel_,
+                 variation.first, step++, weight);
 
     if (variation.first == Central)
-        mcWeights_->Fill(weight/std::abs(refWeight));
+        mcWeights_->Fill(weight / std::abs(refWeight));
 
-    if (doFiducial_ && lep.pt() < 25)
-        return;
+    if (doFiducial_ && lep.pt() < 25) return;
 
     float ptl_smear_fill = ptl_smear;
     if (variation.first == muonScaleUp)
@@ -200,114 +229,216 @@ void WGenSelector::FillHistogramsByName(Long64_t entry, std::string& toAppend, S
     else if (variation.first == muonScaleDown)
         ptl_smear_fill *= 0.999;
 
-    if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(), variation.first) != theoryVarSysts_.end()) {
-        size_t minimalWeights = *nLHEScaleWeight+nLHEScaleWeightAltSet1+nLHEUnknownWeight+nLHEUnknownWeightAltSet1;
-        size_t nWeights = variation.first == Central ? minimalWeights : minimalWeights+nLHEPdfWeight;
+    if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(),
+                  variation.first) != theoryVarSysts_.end()) {
+        size_t minimalWeights = *nLHEScaleWeight + nLHEScaleWeightAltSet1 +
+                                nLHEUnknownWeight + nLHEUnknownWeightAltSet1;
+        size_t nWeights = variation.first == Central
+                              ? minimalWeights
+                              : minimalWeights + nLHEPdfWeight;
 
         for (size_t i = 0; i < nWeights; i++) {
             float thweight = 1;
             if (i < *nLHEScaleWeight)
                 thweight = LHEScaleWeight[i];
-            else if (i < *nLHEScaleWeight+nLHEScaleWeightAltSet1)
-                thweight = LHEScaleWeightAltSet1[i-*nLHEScaleWeight];
-            else if (i < minimalWeights-nLHEUnknownWeightAltSet1)
-                thweight = LHEUnknownWeight[i-minimalWeights+nLHEUnknownWeight+nLHEUnknownWeightAltSet1];
+            else if (i < *nLHEScaleWeight + nLHEScaleWeightAltSet1)
+                thweight = LHEScaleWeightAltSet1[i - *nLHEScaleWeight];
+            else if (i < minimalWeights - nLHEUnknownWeightAltSet1)
+                thweight =
+                    LHEUnknownWeight[i - minimalWeights + nLHEUnknownWeight +
+                                     nLHEUnknownWeightAltSet1];
             else if (i < minimalWeights)
-                thweight = LHEUnknownWeight[i-minimalWeights+nLHEUnknownWeightAltSet1];
-            else 
-                thweight = LHEPdfWeight[i-minimalWeights];
+                thweight = LHEUnknownWeight[i - minimalWeights +
+                                            nLHEUnknownWeightAltSet1];
+            else
+                thweight = LHEPdfWeight[i - minimalWeights];
 
             if (centralWeightIndex_ != -1)
                 thweight /= LHEScaleWeight.At(centralWeightIndex_);
 
-            if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) && ptVlhe > 3.) ||
-                    ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) && (ptVlhe < 3. || ptVlhe > 5.))  ||
-                    ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) && (ptVlhe < 5. || ptVlhe > 7.)) ||
-                    ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) && (ptVlhe < 7. || ptVlhe > 9.)) ||
-                    ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) && (ptVlhe < 9. || ptVlhe > 12.)) ||
-                    ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) && (ptVlhe < 12. || ptVlhe > 15.)) ||
-                    ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) && (ptVlhe < 15. || ptVlhe > 20.)) ||
-                    ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) && (ptVlhe < 20. || ptVlhe > 27.)) ||
-                    ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) && (ptVlhe < 27. || ptVlhe > 40.)) ||
-                    ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) && ptVlhe < 40. )) {
+            if (((variation.first == ptV0to3 ||
+                  variation.first == ptV0to3_lhe) &&
+                 ptVlhe > 3.) ||
+                ((variation.first == ptV3to5 ||
+                  variation.first == ptV3to5_lhe) &&
+                 (ptVlhe < 3. || ptVlhe > 5.)) ||
+                ((variation.first == ptV5to7 ||
+                  variation.first == ptV5to7_lhe) &&
+                 (ptVlhe < 5. || ptVlhe > 7.)) ||
+                ((variation.first == ptV7to9 ||
+                  variation.first == ptV7to9_lhe) &&
+                 (ptVlhe < 7. || ptVlhe > 9.)) ||
+                ((variation.first == ptV9to12 ||
+                  variation.first == ptV9to12_lhe) &&
+                 (ptVlhe < 9. || ptVlhe > 12.)) ||
+                ((variation.first == ptV12to15 ||
+                  variation.first == ptV12to15_lhe) &&
+                 (ptVlhe < 12. || ptVlhe > 15.)) ||
+                ((variation.first == ptV15to20 ||
+                  variation.first == ptV15to20_lhe) &&
+                 (ptVlhe < 15. || ptVlhe > 20.)) ||
+                ((variation.first == ptV20to27 ||
+                  variation.first == ptV20to27_lhe) &&
+                 (ptVlhe < 20. || ptVlhe > 27.)) ||
+                ((variation.first == ptV27to40 ||
+                  variation.first == ptV27to40_lhe) &&
+                 (ptVlhe < 27. || ptVlhe > 40.)) ||
+                ((variation.first == ptV40toInf ||
+                  variation.first == ptV40toInf_lhe) &&
+                 ptVlhe < 40.)) {
                 thweight = 1;
             }
 
             thweight *= weight;
-            SafeHistFill(weighthistMap1D_, concatenateNames("mW", toAppend), channel_, variation.first, wCand.mass(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("yW", toAppend), channel_, variation.first, wCand.Rapidity(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("ptW", toAppend), channel_, variation.first, wCand.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("mWmet", toAppend), channel_, variation.first, wCandMet.mass(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("yWmet", toAppend), channel_, variation.first, wCandMet.Rapidity(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("ptWmet", toAppend), channel_, variation.first, wCandMet.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("MET", toAppend), channel_, variation.first, genMet.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("MET_phi", toAppend), channel_, variation.first, genMet.phi(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("ptl", toAppend), channel_, variation.first, lep.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("ptl_smear", toAppend), channel_, variation.first, ptl_smear_fill, i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("etal", toAppend), channel_, variation.first, lep.eta(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("phil", toAppend), channel_, variation.first, lep.phi(), i, thweight);
-            SafeHistFill(weighthistMap1D_, concatenateNames("nJets", toAppend), channel_, variation.first, jets.size(), i, thweight);
-            SafeHistFill(weighthistMap2D_, concatenateNames("etal_ptl_2D", toAppend), channel_, variation.first, lep.eta(), lep.pt(), i, thweight);
-            SafeHistFill(weighthistMap2D_, concatenateNames("etal_ptl_smear_2D", toAppend), channel_, variation.first, lep.eta(), ptl_smear_fill, i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("mW", toAppend),
+                         channel_, variation.first, wCand.mass(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("yW", toAppend),
+                         channel_, variation.first, wCand.Rapidity(), i,
+                         thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("ptW", toAppend),
+                         channel_, variation.first, wCand.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("mWmet", toAppend),
+                         channel_, variation.first, wCandMet.mass(), i,
+                         thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("yWmet", toAppend),
+                         channel_, variation.first, wCandMet.Rapidity(), i,
+                         thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("ptWmet", toAppend),
+                         channel_, variation.first, wCandMet.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("MET", toAppend),
+                         channel_, variation.first, genMet.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_,
+                         concatenateNames("MET_phi", toAppend), channel_,
+                         variation.first, genMet.phi(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("ptl", toAppend),
+                         channel_, variation.first, lep.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_,
+                         concatenateNames("ptl_smear", toAppend), channel_,
+                         variation.first, ptl_smear_fill, i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("etal", toAppend),
+                         channel_, variation.first, lep.eta(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("phil", toAppend),
+                         channel_, variation.first, lep.phi(), i, thweight);
+            SafeHistFill(weighthistMap1D_, concatenateNames("nJets", toAppend),
+                         channel_, variation.first, jets.size(), i, thweight);
+            SafeHistFill(weighthistMap2D_,
+                         concatenateNames("etal_ptl_2D", toAppend), channel_,
+                         variation.first, lep.eta(), lep.pt(), i, thweight);
+            SafeHistFill(weighthistMap2D_,
+                         concatenateNames("etal_ptl_smear_2D", toAppend),
+                         channel_, variation.first, lep.eta(), ptl_smear_fill,
+                         i, thweight);
         }
     }
 
-    if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) && ptVlhe > 3.) ||
-            ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) && (ptVlhe < 3. || ptVlhe > 5.))  ||
-            ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) && (ptVlhe < 5. || ptVlhe > 7.)) ||
-            ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) && (ptVlhe < 7. || ptVlhe > 9.)) ||
-            ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) && (ptVlhe < 9. || ptVlhe > 12.)) ||
-            ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) && (ptVlhe < 12. || ptVlhe > 15.)) ||
-            ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) && (ptVlhe < 15. || ptVlhe > 20.)) ||
-            ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) && (ptVlhe < 20. || ptVlhe > 27.)) ||
-            ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) && (ptVlhe < 27. || ptVlhe > 40.)) ||
-            ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) && ptVlhe < 40. )) {
+    if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) &&
+         ptVlhe > 3.) ||
+        ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) &&
+         (ptVlhe < 3. || ptVlhe > 5.)) ||
+        ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) &&
+         (ptVlhe < 5. || ptVlhe > 7.)) ||
+        ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) &&
+         (ptVlhe < 7. || ptVlhe > 9.)) ||
+        ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) &&
+         (ptVlhe < 9. || ptVlhe > 12.)) ||
+        ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) &&
+         (ptVlhe < 12. || ptVlhe > 15.)) ||
+        ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) &&
+         (ptVlhe < 15. || ptVlhe > 20.)) ||
+        ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) &&
+         (ptVlhe < 20. || ptVlhe > 27.)) ||
+        ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) &&
+         (ptVlhe < 27. || ptVlhe > 40.)) ||
+        ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) &&
+         ptVlhe < 40.)) {
         return;
     }
 
-    SafeHistFill(histMap1D_, concatenateNames("mW", toAppend), channel_, variation.first, wCand.mass(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("yW", toAppend), channel_, variation.first, wCand.Rapidity(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("ptW", toAppend), channel_, variation.first, wCand.pt(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("mTtrue", toAppend), channel_, variation.first, mTtrue, weight);
-    SafeHistFill(histMap1D_, concatenateNames("mTmet", toAppend), channel_, variation.first, mTmet, weight);
-    SafeHistFill(histMap1D_, concatenateNames("mWmet", toAppend), channel_, variation.first, wCandMet.mass(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("yWmet", toAppend), channel_, variation.first, wCandMet.Rapidity(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("ptWmet", toAppend), channel_, variation.first, wCandMet.pt(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("MET", toAppend), channel_, variation.first, genMet.pt(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("MET_phi", toAppend), channel_, variation.first, genMet.phi(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("ptl", toAppend), channel_, variation.first, lep.pt(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("ptl_smear", toAppend), channel_, variation.first, ptl_smear_fill, weight);
-    SafeHistFill(histMap1D_, concatenateNames("etal", toAppend), channel_, variation.first, lep.eta(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("phil", toAppend), channel_, variation.first, lep.phi(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("ptnu", toAppend), channel_, variation.first, nu.pt(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("etanu", toAppend), channel_, variation.first, nu.eta(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("phinu", toAppend), channel_, variation.first, nu.phi(), weight);
-    SafeHistFill(histMap1D_, concatenateNames("nJets", toAppend), channel_, variation.first, jets.size(), weight);
-    SafeHistFill(histMap2D_, concatenateNames("etal_ptl_2D", toAppend), channel_, variation.first, lep.eta(), lep.pt(), weight);
-    SafeHistFill(histMap2D_, concatenateNames("etal_ptl_smear_2D", toAppend), channel_, variation.first, lep.eta(), ptl_smear_fill, weight);
+    SafeHistFill(histMap1D_, concatenateNames("mW", toAppend), channel_,
+                 variation.first, wCand.mass(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("yW", toAppend), channel_,
+                 variation.first, wCand.Rapidity(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("ptW", toAppend), channel_,
+                 variation.first, wCand.pt(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("mTtrue", toAppend), channel_,
+                 variation.first, mTtrue, weight);
+    SafeHistFill(histMap1D_, concatenateNames("mTmet", toAppend), channel_,
+                 variation.first, mTmet, weight);
+    SafeHistFill(histMap1D_, concatenateNames("mWmet", toAppend), channel_,
+                 variation.first, wCandMet.mass(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("yWmet", toAppend), channel_,
+                 variation.first, wCandMet.Rapidity(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("ptWmet", toAppend), channel_,
+                 variation.first, wCandMet.pt(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("MET", toAppend), channel_,
+                 variation.first, genMet.pt(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("MET_phi", toAppend), channel_,
+                 variation.first, genMet.phi(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("ptl", toAppend), channel_,
+                 variation.first, lep.pt(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("ptl_smear", toAppend), channel_,
+                 variation.first, ptl_smear_fill, weight);
+    SafeHistFill(histMap1D_, concatenateNames("etal", toAppend), channel_,
+                 variation.first, lep.eta(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("phil", toAppend), channel_,
+                 variation.first, lep.phi(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("ptnu", toAppend), channel_,
+                 variation.first, nu.pt(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("etanu", toAppend), channel_,
+                 variation.first, nu.eta(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("phinu", toAppend), channel_,
+                 variation.first, nu.phi(), weight);
+    SafeHistFill(histMap1D_, concatenateNames("nJets", toAppend), channel_,
+                 variation.first, jets.size(), weight);
+    SafeHistFill(histMap2D_, concatenateNames("etal_ptl_2D", toAppend),
+                 channel_, variation.first, lep.eta(), lep.pt(), weight);
+    SafeHistFill(histMap2D_, concatenateNames("etal_ptl_smear_2D", toAppend),
+                 channel_, variation.first, lep.eta(), ptl_smear_fill, weight);
     for (size_t i = 1; i <= 3; i++) {
-        if (jets.size() >= i ) {
-            const auto& jet = jets.at(i-1);
-            SafeHistFill(histMap1D_, concatenateNames(("ptj"+std::to_string(i)).c_str(), toAppend), channel_, variation.first, jet.pt(), weight);
-            SafeHistFill(histMap1D_, concatenateNames(("etaj"+std::to_string(i)).c_str(), toAppend), channel_, variation.first, jet.eta(), weight);
-            SafeHistFill(histMap1D_, concatenateNames(("phij"+std::to_string(i)).c_str(), toAppend), channel_, variation.first, jet.phi(), weight);
-        }  
+        if (jets.size() >= i) {
+            const auto& jet = jets.at(i - 1);
+            SafeHistFill(
+                histMap1D_,
+                concatenateNames(("ptj" + std::to_string(i)).c_str(), toAppend),
+                channel_, variation.first, jet.pt(), weight);
+            SafeHistFill(histMap1D_,
+                         concatenateNames(("etaj" + std::to_string(i)).c_str(),
+                                          toAppend),
+                         channel_, variation.first, jet.eta(), weight);
+            SafeHistFill(histMap1D_,
+                         concatenateNames(("phij" + std::to_string(i)).c_str(),
+                                          toAppend),
+                         channel_, variation.first, jet.phi(), weight);
+        }
     }
 
     if (variation.first == BareLeptons) {
-        SafeHistFill(histMap1D_, "nGammaAssoc", channel_, variation.first, photons.size(), weight);
+        SafeHistFill(histMap1D_, "nGammaAssoc", channel_, variation.first,
+                     photons.size(), weight);
 
-        auto compareByPt = [](const reco::GenParticle& a, const reco::GenParticle& b) { return a.pt() < b.pt(); };
-        auto compareByDRLead = [lep] (const reco::GenParticle& a, const reco::GenParticle& b) {
+        auto compareByPt = [](const reco::GenParticle& a,
+                              const reco::GenParticle& b) {
+            return a.pt() < b.pt();
+        };
+        auto compareByDRLead = [lep](const reco::GenParticle& a,
+                                     const reco::GenParticle& b) {
             return reco::deltaR(a, lep) < reco::deltaR(b, lep);
         };
 
-        auto gclose = std::min_element(photons.begin(), photons.end(), compareByDRLead);
-        auto maxPtg = std::max_element(photons.begin(), photons.end(), compareByPt);
+        auto gclose =
+            std::min_element(photons.begin(), photons.end(), compareByDRLead);
+        auto maxPtg =
+            std::max_element(photons.begin(), photons.end(), compareByPt);
 
-        SafeHistFill(histMap1D_, "dRlgamma_minassoc", channel_, variation.first, photons.size() > 0 ? reco::deltaR(*gclose, lep) : 0., weight);
-        SafeHistFill(histMap1D_, "dRlgamma_maxptassoc", channel_, variation.first, photons.size() > 0 ? reco::deltaR(*maxPtg, lep) : 0., weight);
-        SafeHistFill(histMap1D_, "ptg_closeassoc", channel_, variation.first, photons.size() > 0 ? gclose->pt() : 0., weight);
-        SafeHistFill(histMap1D_, "ptgmax_assoc", channel_, variation.first, photons.size() > 0 ? maxPtg->pt() : 0., weight);
+        SafeHistFill(histMap1D_, "dRlgamma_minassoc", channel_, variation.first,
+                     photons.size() > 0 ? reco::deltaR(*gclose, lep) : 0.,
+                     weight);
+        SafeHistFill(
+            histMap1D_, "dRlgamma_maxptassoc", channel_, variation.first,
+            photons.size() > 0 ? reco::deltaR(*maxPtg, lep) : 0., weight);
+        SafeHistFill(histMap1D_, "ptg_closeassoc", channel_, variation.first,
+                     photons.size() > 0 ? gclose->pt() : 0., weight);
+        SafeHistFill(histMap1D_, "ptgmax_assoc", channel_, variation.first,
+                     photons.size() > 0 ? maxPtg->pt() : 0., weight);
     }
 }

--- a/src/WZBackgroundSelector.cc
+++ b/src/WZBackgroundSelector.cc
@@ -1,107 +1,115 @@
 #include "Analysis/VVAnalysis/interface/WZBackgroundSelector.h"
 #include <TStyle.h>
 
-void WZBackgroundSelector::SlaveBegin(TTree * /*tree*/)
-{
+void WZBackgroundSelector::SlaveBegin(TTree * /*tree*/) {
     systematics_ = {
-        {jetEnergyScaleUp, "CMS_scale_jUp"}, 
-        {jetEnergyScaleDown, "CMS_scale_jDown"}, 
+        {jetEnergyScaleUp, "CMS_scale_jUp"},
+        {jetEnergyScaleDown, "CMS_scale_jDown"},
         {jetEnergyResolutionUp, "CMS_res_jUp"},
         {jetEnergyResolutionDown, "CMS_res_jDown"},
     };
     isNonpromptEstimate_ = true;
     doaQGC_ = false;
     WZSelector::SlaveBegin(0);
-    fakeRate_allE_ = (ScaleFactor *) GetInputList()->FindObject("fakeRate_allE");
-    if (fakeRate_allE_ == nullptr ) Abort("Must pass electron fake rate to input list!");
-    fakeRate_allMu_ = (ScaleFactor *) GetInputList()->FindObject("fakeRate_allMu");
-    if (fakeRate_allMu_ == nullptr ) Abort("Must pass muon fake rate to input list!");
+    fakeRate_allE_ = (ScaleFactor *)GetInputList()->FindObject("fakeRate_allE");
+    if (fakeRate_allE_ == nullptr)
+        Abort("Must pass electron fake rate to input list!");
+    fakeRate_allMu_ =
+        (ScaleFactor *)GetInputList()->FindObject("fakeRate_allMu");
+    if (fakeRate_allMu_ == nullptr)
+        Abort("Must pass muon fake rate to input list!");
 }
 
-void WZBackgroundSelector::SetupNewDirectory()
-{
+void WZBackgroundSelector::SetupNewDirectory() {
     WZSelector::SetupNewDirectory();
-   
-    // Insure that hist ranges are exactly the same as WZSelector, just change name
-    for (const auto && obj : *currentHistDir_) {
+
+    // Insure that hist ranges are exactly the same as WZSelector, just change
+    // name
+    for (const auto &&obj : *currentHistDir_) {
         std::string name = obj->GetName();
-        TNamed* named = dynamic_cast<TNamed*>(obj);
-        named->SetName(name.insert(name.length()-3, "Fakes_").c_str());
+        TNamed *named = dynamic_cast<TNamed *>(obj);
+        named->SetName(name.insert(name.length() - 3, "Fakes_").c_str());
     }
-    
-    AddObject<TH1D>(mjjHistPPF_, ("mjj_PPF_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistPFP_, ("mjj_PFP_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistFPP_, ("mjj_FPP_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistFFP_, ("mjj_FFP_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistFPF_, ("mjj_FPF_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistPFF_, ("mjj_PFF_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(mjjHistFFF_, ("mjj_FFF_"+channelName_).c_str(), "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
-    AddObject<TH1D>(ZMassHistPPF_, ("ZMass_PPF_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistPFP_, ("ZMass_PFP_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistFPP_, ("ZMass_FPP_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistFFP_, ("ZMass_FFP_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistFPF_, ("ZMass_FPF_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistPFF_, ("ZMass_PFF_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
-    AddObject<TH1D>(ZMassHistFFF_, ("ZMass_FFF_"+channelName_).c_str(), "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+
+    AddObject<TH1D>(mjjHistPPF_, ("mjj_PPF_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistPFP_, ("mjj_PFP_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistFPP_, ("mjj_FPP_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistFFP_, ("mjj_FFP_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistFPF_, ("mjj_FPF_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistPFF_, ("mjj_PFF_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(mjjHistFFF_, ("mjj_FFF_" + channelName_).c_str(),
+                    "mjj; m_{jj} [GeV]; Events;", 15, 0, 1500);
+    AddObject<TH1D>(ZMassHistPPF_, ("ZMass_PPF_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistPFP_, ("ZMass_PFP_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistFPP_, ("ZMass_FPP_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistFFP_, ("ZMass_FFP_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistFPF_, ("ZMass_FPF_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistPFF_, ("ZMass_PFF_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
+    AddObject<TH1D>(ZMassHistFFF_, ("ZMass_FFF_" + channelName_).c_str(),
+                    "ZMass; m_{Z} [GeV]; Events;", 15, 76, 116);
 }
 float WZBackgroundSelector::getEventWeight() {
     float evtwgt = 0;
-    if (!IsGenMatched3l())
-        return true;
+    if (!IsGenMatched3l()) return true;
 
     if (IsFPPRegion()) {
-        if (!isVBS_ || PassesVBSSelection(true))
-            mjjHistFPP_->Fill(mjj, weight);
-        evtwgt = getl1FakeRate()*weight;
-    }
-    else if (IsPFPRegion()) {
+        if (!isVBS_ || PassesVBSSelection(true)) mjjHistFPP_->Fill(mjj, weight);
+        evtwgt = getl1FakeRate() * weight;
+    } else if (IsPFPRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistPFP_->Fill(mjj, weight);
             ZMassHistPFP_->Fill(ZMass, weight);
         }
-        evtwgt = getl2FakeRate()*weight;
-    }
-    else if (IsPPFRegion()) {
+        evtwgt = getl2FakeRate() * weight;
+    } else if (IsPPFRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistPPF_->Fill(mjj, weight);
             ZMassHistPPF_->Fill(ZMass, weight);
         }
-        evtwgt = getl3FakeRate()*weight;
-    }
-    else if (IsFFFRegion()) {
+        evtwgt = getl3FakeRate() * weight;
+    } else if (IsFFFRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistFFF_->Fill(mjj, weight);
             ZMassHistFFF_->Fill(ZMass, weight);
         }
-        evtwgt = getl1FakeRate()*getl2FakeRate()*getl3FakeRate()*weight;
-    }
-    else if (IsFPFRegion()) {
+        evtwgt = getl1FakeRate() * getl2FakeRate() * getl3FakeRate() * weight;
+    } else if (IsFPFRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistFPF_->Fill(mjj, weight);
             ZMassHistFPF_->Fill(ZMass, weight);
         }
-        evtwgt = -1*getl1FakeRate()*getl3FakeRate()*weight;
-    }
-    else if (IsFFPRegion()) {
+        evtwgt = -1 * getl1FakeRate() * getl3FakeRate() * weight;
+    } else if (IsFFPRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistFFP_->Fill(mjj, weight);
             ZMassHistFFP_->Fill(ZMass, weight);
         }
-        evtwgt = -1*getl1FakeRate()*getl2FakeRate()*weight;
-    }
-    else if (IsPFFRegion()) {
+        evtwgt = -1 * getl1FakeRate() * getl2FakeRate() * weight;
+    } else if (IsPFFRegion()) {
         if (!isVBS_ || PassesVBSSelection(true)) {
             mjjHistPFF_->Fill(mjj, weight);
             ZMassHistPFF_->Fill(ZMass, weight);
         }
-        evtwgt = -1*getl2FakeRate()*getl3FakeRate()*weight;
+        evtwgt = -1 * getl2FakeRate() * getl3FakeRate() * weight;
     }
-    if (isMC_)
-        evtwgt *= GetPrefiringEfficiencyWeight(jetPt, jetEta);
+    if (isMC_) evtwgt *= GetPrefiringEfficiencyWeight(jetPt, jetEta);
     return evtwgt;
 }
 
-void WZBackgroundSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void WZBackgroundSelector::LoadBranchesUWVV(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     WZSelector::LoadBranches(entry, variation);
     weight = getEventWeight();
 }
@@ -109,11 +117,11 @@ void WZBackgroundSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic
 float WZBackgroundSelector::getl1FakeRate() {
     float pt_fillval = l1Pt < FR_MAX_PT_ ? l1Pt : FR_MAX_PT_ - 0.01;
     float fr = 1;
-    if (channel_ == eem|| channel_ == eee)
+    if (channel_ == eem || channel_ == eee)
         fr = fakeRate_allE_->Evaluate2D(pt_fillval, std::abs(l1Eta));
     else
         fr = fakeRate_allMu_->Evaluate2D(pt_fillval, std::abs(l1Eta));
-    return fr/(1-fr); 
+    return fr / (1 - fr);
 }
 
 float WZBackgroundSelector::getl2FakeRate() {
@@ -123,7 +131,7 @@ float WZBackgroundSelector::getl2FakeRate() {
         fr = fakeRate_allE_->Evaluate2D(pt_fillval, std::abs(l2Eta));
     else
         fr = fakeRate_allMu_->Evaluate2D(pt_fillval, std::abs(l2Eta));
-    return fr/(1-fr); 
+    return fr / (1 - fr);
 }
 
 float WZBackgroundSelector::getl3FakeRate() {
@@ -133,7 +141,7 @@ float WZBackgroundSelector::getl3FakeRate() {
         fr = fakeRate_allE_->Evaluate2D(pt_fillval, std::abs(l3Eta));
     else
         fr = fakeRate_allMu_->Evaluate2D(pt_fillval, std::abs(l3Eta));
-    return fr/(1-fr); 
+    return fr / (1 - fr);
 }
 
 bool WZBackgroundSelector::IsFPPRegion() {

--- a/src/WZSelector.cc
+++ b/src/WZSelector.cc
@@ -1,16 +1,15 @@
 #include "Analysis/VVAnalysis/interface/WZSelector.h"
 #include "TLorentzVector.h"
 
-void WZSelector::Init(TTree *tree)
-{
+void WZSelector::Init(TTree* tree) {
     weight_info_ = 0;
     if (isMC_) {
         weight_info_ = GetLheWeightInfo();
     }
 
     systematics_ = {
-        {jetEnergyScaleUp, "CMS_scale_jUp"}, 
-        {jetEnergyScaleDown, "CMS_scale_jDown"}, 
+        {jetEnergyScaleUp, "CMS_scale_jUp"},
+        {jetEnergyScaleDown, "CMS_scale_jDown"},
         {jetEnergyResolutionUp, "CMS_res_jUp"},
         {jetEnergyResolutionDown, "CMS_res_jDown"},
         {metUnclusteredEnergyUp, "CMS_scale_unclEnergyUp"},
@@ -35,9 +34,10 @@ void WZSelector::Init(TTree *tree)
         //"MTWZ",
     };
 
-    hists1D_ = {"yield", "Zlep1_Eta", "Zlep1_Phi", "Zlep1_Pt",
-        "Zlep2_Eta", "Zlep2_Phi", "Zlep2_Pt", "Wlep_Eta", "Wlep_Phi", "Wlep_Pt",
-        "ZMass", "Mass", "MET", "nJets",
+    hists1D_ = {
+        "yield",     "Zlep1_Eta", "Zlep1_Phi", "Zlep1_Pt", "Zlep2_Eta",
+        "Zlep2_Phi", "Zlep2_Pt",  "Wlep_Eta",  "Wlep_Phi", "Wlep_Pt",
+        "ZMass",     "Mass",      "MET",       "nJets",
         //"ZPt",
         //"ZEta",
         //"ZPhi",
@@ -71,59 +71,81 @@ void WZSelector::Init(TTree *tree)
     WZSelectorBase::Init(tree);
 }
 
-// Values from https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceScaleResolRun2
+// Values from
+// https://twiki.cern.ch/twiki/bin/viewauth/CMS/MuonReferenceScaleResolRun2
 float WZSelector::GetMuonScaleUncertainty(float muEta) {
-    if (muEta < -2.1)
-        return 0.027;
-    if (std::abs(muEta) < 2.1 && std::abs(muEta) > 1.2)
-        return 0.009;
-    if (std::abs(muEta) < 1.2)
-        return 0.004;
-    if (muEta > 2.1)
-        return 0.0017;
-    throw std::out_of_range("Muon eta out of range of possible values! Range was " + std::to_string(muEta));
+    if (muEta < -2.1) return 0.027;
+    if (std::abs(muEta) < 2.1 && std::abs(muEta) > 1.2) return 0.009;
+    if (std::abs(muEta) < 1.2) return 0.004;
+    if (muEta > 2.1) return 0.0017;
+    throw std::out_of_range(
+        "Muon eta out of range of possible values! Range was " +
+        std::to_string(muEta));
 }
 
 void WZSelector::SetBranchesUWVV() {
     WZSelectorBase::SetBranchesUWVV();
     if (isMC_) {
         if (weight_info_ > 0)
-            fChain->SetBranchAddress("scaleWeights", &scaleWeights, &b_scaleWeights);
+            fChain->SetBranchAddress("scaleWeights", &scaleWeights,
+                                     &b_scaleWeights);
         if ((weight_info_ == 2 || weight_info_ == 3) && doSystematics_)
             fChain->SetBranchAddress("pdfWeights", &pdfWeights, &b_pdfWeights);
         fChain->SetBranchAddress("mjj_jesUp", &mjj_jesUp, &b_mjj_jesUp);
         fChain->SetBranchAddress("mjj_jesDown", &mjj_jesDown, &b_mjj_jesDown);
         fChain->SetBranchAddress("mjj_jerUp", &mjj_jerUp, &b_mjj_jerUp);
         fChain->SetBranchAddress("mjj_jerDown", &mjj_jerDown, &b_mjj_jerDown);
-        fChain->SetBranchAddress("jetEta_jesUp", &jetEta_jesUp, &b_jetEta_jesUp);
-        fChain->SetBranchAddress("jetEta_jesDown", &jetEta_jesDown, &b_jetEta_jesDown);
-        fChain->SetBranchAddress("jetEta_jerUp", &jetEta_jerUp, &b_jetEta_jerUp);
-        fChain->SetBranchAddress("jetEta_jerDown", &jetEta_jerDown, &b_jetEta_jerDown);
+        fChain->SetBranchAddress("jetEta_jesUp", &jetEta_jesUp,
+                                 &b_jetEta_jesUp);
+        fChain->SetBranchAddress("jetEta_jesDown", &jetEta_jesDown,
+                                 &b_jetEta_jesDown);
+        fChain->SetBranchAddress("jetEta_jerUp", &jetEta_jerUp,
+                                 &b_jetEta_jerUp);
+        fChain->SetBranchAddress("jetEta_jerDown", &jetEta_jerDown,
+                                 &b_jetEta_jerDown);
         fChain->SetBranchAddress("jetPt_jesUp", &jetPt_jesUp, &b_jetPt_jesUp);
-        fChain->SetBranchAddress("jetPt_jesDown", &jetPt_jesDown, &b_jetPt_jesDown);
+        fChain->SetBranchAddress("jetPt_jesDown", &jetPt_jesDown,
+                                 &b_jetPt_jesDown);
         fChain->SetBranchAddress("jetPt_jerUp", &jetPt_jerUp, &b_jetPt_jerUp);
-        fChain->SetBranchAddress("jetPt_jerDown", &jetPt_jerDown, &b_jetPt_jerDown);
-        fChain->SetBranchAddress("type1_pfMETEt_jesUp", &type1_pfMETEt_jesUp, &b_type1_pfMETEt_jesUp);
-        fChain->SetBranchAddress("type1_pfMETEt_jesDown", &type1_pfMETEt_jesDown, &b_type1_pfMETEt_jesDown);
-        fChain->SetBranchAddress("type1_pfMETEt_jerUp", &type1_pfMETEt_jerUp, &b_type1_pfMETEt_jerUp);
-        fChain->SetBranchAddress("type1_pfMETEt_jerDown", &type1_pfMETEt_jerDown, &b_type1_pfMETEt_jerDown);
-        fChain->SetBranchAddress("type1_pfMETEt_unclusteredEnUp", &type1_pfMETEt_unclusteredEnUp, &b_type1_pfMETEt_unclusteredEnUp);
-        fChain->SetBranchAddress("type1_pfMETEt_unclusteredEnDown", &type1_pfMETEt_unclusteredEnDown, &b_type1_pfMETEt_unclusteredEnDown);
-        fChain->SetBranchAddress("type1_pfMETEt_UncTool", &type1_pfMETEt_UncTool, &b_type1_pfMETEt_UncTool);
+        fChain->SetBranchAddress("jetPt_jerDown", &jetPt_jerDown,
+                                 &b_jetPt_jerDown);
+        fChain->SetBranchAddress("type1_pfMETEt_jesUp", &type1_pfMETEt_jesUp,
+                                 &b_type1_pfMETEt_jesUp);
+        fChain->SetBranchAddress("type1_pfMETEt_jesDown",
+                                 &type1_pfMETEt_jesDown,
+                                 &b_type1_pfMETEt_jesDown);
+        fChain->SetBranchAddress("type1_pfMETEt_jerUp", &type1_pfMETEt_jerUp,
+                                 &b_type1_pfMETEt_jerUp);
+        fChain->SetBranchAddress("type1_pfMETEt_jerDown",
+                                 &type1_pfMETEt_jerDown,
+                                 &b_type1_pfMETEt_jerDown);
+        fChain->SetBranchAddress("type1_pfMETEt_unclusteredEnUp",
+                                 &type1_pfMETEt_unclusteredEnUp,
+                                 &b_type1_pfMETEt_unclusteredEnUp);
+        fChain->SetBranchAddress("type1_pfMETEt_unclusteredEnDown",
+                                 &type1_pfMETEt_unclusteredEnDown,
+                                 &b_type1_pfMETEt_unclusteredEnDown);
+        fChain->SetBranchAddress("type1_pfMETEt_UncTool",
+                                 &type1_pfMETEt_UncTool,
+                                 &b_type1_pfMETEt_UncTool);
         if (channel_ == eee) {
-            fChain->SetBranchAddress("e1scaleCorrError", &l1PtScaleCorrErr, &b_l1PtScaleCorrErr);
-            fChain->SetBranchAddress("e2scaleCorrError", &l2PtScaleCorrErr, &b_l2PtScaleCorrErr);
-            fChain->SetBranchAddress("e3scaleCorrError", &l3PtScaleCorrErr, &b_l3PtScaleCorrErr);
-        }
-        else if (channel_ == eem) {
-            fChain->SetBranchAddress("e1scaleCorrError", &l1PtScaleCorrErr, &b_l1PtScaleCorrErr);
-            fChain->SetBranchAddress("e2scaleCorrError", &l2PtScaleCorrErr, &b_l2PtScaleCorrErr);
-        }
-        else if (channel_ == emm) {
-            fChain->SetBranchAddress("escaleCorrError", &l3PtScaleCorrErr, &b_l3PtScaleCorrErr);
+            fChain->SetBranchAddress("e1scaleCorrError", &l1PtScaleCorrErr,
+                                     &b_l1PtScaleCorrErr);
+            fChain->SetBranchAddress("e2scaleCorrError", &l2PtScaleCorrErr,
+                                     &b_l2PtScaleCorrErr);
+            fChain->SetBranchAddress("e3scaleCorrError", &l3PtScaleCorrErr,
+                                     &b_l3PtScaleCorrErr);
+        } else if (channel_ == eem) {
+            fChain->SetBranchAddress("e1scaleCorrError", &l1PtScaleCorrErr,
+                                     &b_l1PtScaleCorrErr);
+            fChain->SetBranchAddress("e2scaleCorrError", &l2PtScaleCorrErr,
+                                     &b_l2PtScaleCorrErr);
+        } else if (channel_ == emm) {
+            fChain->SetBranchAddress("escaleCorrError", &l3PtScaleCorrErr,
+                                     &b_l3PtScaleCorrErr);
         }
     }
-    
+
     fChain->SetBranchAddress("jetPt", &jetPt, &b_jetPt);
     fChain->SetBranchAddress("jetPhi", &jetPhi, &b_jetPhi);
     fChain->SetBranchAddress("jetEta", &jetEta, &b_jetEta);
@@ -134,68 +156,84 @@ void WZSelector::SetBranchesUWVV() {
     fChain->SetBranchAddress("mjj", &mjj, &b_mjj);
 
     if (channel_ == eee) {
-        fChain->SetBranchAddress("e1_e3_Mass", &Zlep1_Wlep_Mass, &b_Zlep1_Wlep_Mass);
-        fChain->SetBranchAddress("e2_e3_Mass", &Zlep2_Wlep_Mass, &b_Zlep2_Wlep_Mass);
+        fChain->SetBranchAddress("e1_e3_Mass", &Zlep1_Wlep_Mass,
+                                 &b_Zlep1_Wlep_Mass);
+        fChain->SetBranchAddress("e2_e3_Mass", &Zlep2_Wlep_Mass,
+                                 &b_Zlep2_Wlep_Mass);
         fChain->SetBranchAddress("e1_e2_Pt", &ZPt, &b_ZPt);
         fChain->SetBranchAddress("e1_e2_Eta", &ZEta, &b_ZEta);
         fChain->SetBranchAddress("e1_e2_Phi", &ZPhi, &b_ZPhi);
-    }
-    else if (channel_ == eem) { 
-        fChain->SetBranchAddress("e1_m_Mass", &Zlep1_Wlep_Mass, &b_Zlep1_Wlep_Mass);
-        fChain->SetBranchAddress("e2_m_Mass", &Zlep2_Wlep_Mass, &b_Zlep2_Wlep_Mass);
+    } else if (channel_ == eem) {
+        fChain->SetBranchAddress("e1_m_Mass", &Zlep1_Wlep_Mass,
+                                 &b_Zlep1_Wlep_Mass);
+        fChain->SetBranchAddress("e2_m_Mass", &Zlep2_Wlep_Mass,
+                                 &b_Zlep2_Wlep_Mass);
         fChain->SetBranchAddress("e1_e2_Pt", &ZPt, &b_ZPt);
         fChain->SetBranchAddress("e1_e2_Eta", &ZEta, &b_ZEta);
         fChain->SetBranchAddress("e1_e2_Phi", &ZPhi, &b_ZPhi);
-    }
-    else if (channel_ == emm) { 
-        fChain->SetBranchAddress("e_m1_Mass", &Zlep1_Wlep_Mass, &b_Zlep1_Wlep_Mass);
-        fChain->SetBranchAddress("e_m2_Mass", &Zlep2_Wlep_Mass, &b_Zlep2_Wlep_Mass);
+    } else if (channel_ == emm) {
+        fChain->SetBranchAddress("e_m1_Mass", &Zlep1_Wlep_Mass,
+                                 &b_Zlep1_Wlep_Mass);
+        fChain->SetBranchAddress("e_m2_Mass", &Zlep2_Wlep_Mass,
+                                 &b_Zlep2_Wlep_Mass);
+        fChain->SetBranchAddress("m1_m2_Pt", &ZPt, &b_ZPt);
+        fChain->SetBranchAddress("m1_m2_Eta", &ZEta, &b_ZEta);
+        fChain->SetBranchAddress("m1_m2_Phi", &ZPhi, &b_ZPhi);
+    } else if (channel_ == mmm) {
+        fChain->SetBranchAddress("m1_m3_Mass", &Zlep1_Wlep_Mass,
+                                 &b_Zlep1_Wlep_Mass);
+        fChain->SetBranchAddress("m2_m3_Mass", &Zlep2_Wlep_Mass,
+                                 &b_Zlep2_Wlep_Mass);
         fChain->SetBranchAddress("m1_m2_Pt", &ZPt, &b_ZPt);
         fChain->SetBranchAddress("m1_m2_Eta", &ZEta, &b_ZEta);
         fChain->SetBranchAddress("m1_m2_Phi", &ZPhi, &b_ZPhi);
     }
-    else if (channel_ == mmm) { 
-        fChain->SetBranchAddress("m1_m3_Mass", &Zlep1_Wlep_Mass, &b_Zlep1_Wlep_Mass);
-        fChain->SetBranchAddress("m2_m3_Mass", &Zlep2_Wlep_Mass, &b_Zlep2_Wlep_Mass);
-        fChain->SetBranchAddress("m1_m2_Pt", &ZPt, &b_ZPt);
-        fChain->SetBranchAddress("m1_m2_Eta", &ZEta, &b_ZEta);
-        fChain->SetBranchAddress("m1_m2_Phi", &ZPhi, &b_ZPhi);
-    }
-
 }
 
 unsigned int WZSelector::GetLheWeightInfo() {
     std::vector<std::string> noLheWeights = {
-        "ggZZ2e2mu", "ggZZ4e", "ggZZ4m", "wzjj-vbfnlo-of",
-        "wzjj-vbfnlo-sf", "st-schan", "st-tchan", "st-tchan-t", "st-tchan-tbar"
-    };
-    std::vector<std::string> scaleAndPdfWeights = {
-        "wz3lnu-powheg", "wz3lnu-mg5amcnlo",
-        "wz3lnu-mgmlm-0j", "wz3lnu-mgmlm-1j",
-        "wz3lnu-mgmlm-2j", "wz3lnu-mgmlm-3j", "wlljj-ewk", 
-        "tzq", "ww", "www", "wwz", "zz-powheg",
-        "zz4l-mg5amcnlo", "zz4ljj-ewk", "zz2l2vjj-ewk"
-    };
+        "ggZZ2e2mu",      "ggZZ4e",         "ggZZ4m",
+        "wzjj-vbfnlo-of", "wzjj-vbfnlo-sf", "st-schan",
+        "st-tchan",       "st-tchan-t",     "st-tchan-tbar"};
+    std::vector<std::string> scaleAndPdfWeights = {"wz3lnu-powheg",
+                                                   "wz3lnu-mg5amcnlo",
+                                                   "wz3lnu-mgmlm-0j",
+                                                   "wz3lnu-mgmlm-1j",
+                                                   "wz3lnu-mgmlm-2j",
+                                                   "wz3lnu-mgmlm-3j",
+                                                   "wlljj-ewk",
+                                                   "tzq",
+                                                   "ww",
+                                                   "www",
+                                                   "wwz",
+                                                   "zz-powheg",
+                                                   "zz4l-mg5amcnlo",
+                                                   "zz4ljj-ewk",
+                                                   "zz2l2vjj-ewk"};
     std::vector<std::string> allLheWeights = {
         "wzjj-aqgcft", "wzjj-aqgcfm", "wzjj-aqgcfs",
         //"wz-atgc_pt0-200", "wz-atgc_pt200-300",
         //"wz-atgc_pt300"
     };
 
-    if (std::find(noLheWeights.begin(), noLheWeights.end(), name_) != noLheWeights.end())
+    if (std::find(noLheWeights.begin(), noLheWeights.end(), name_) !=
+        noLheWeights.end())
         return 0;
-    if (std::find(scaleAndPdfWeights.begin(), scaleAndPdfWeights.end(), name_) != scaleAndPdfWeights.end())
+    if (std::find(scaleAndPdfWeights.begin(), scaleAndPdfWeights.end(),
+                  name_) != scaleAndPdfWeights.end())
         return 2;
-    if (std::find(allLheWeights.begin(), allLheWeights.end(), name_) != allLheWeights.end())
+    if (std::find(allLheWeights.begin(), allLheWeights.end(), name_) !=
+        allLheWeights.end())
         return 3;
     return 1;
 }
 
-void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void WZSelector::LoadBranchesUWVV(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     WZSelectorBase::LoadBranchesUWVV(entry, variation);
-    //weight *= GetPrefiringEfficiencyWeight(jetPt, jetEta);
+    // weight *= GetPrefiringEfficiencyWeight(jetPt, jetEta);
 
-    //b_MtToMET->GetEntry(entry);
+    // b_MtToMET->GetEntry(entry);
     b_ZPhi->GetEntry(entry);
     b_ZEta->GetEntry(entry);
     b_jetPt->GetEntry(entry);
@@ -211,17 +249,20 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
                 if (weight_info_ == 2) {
                     b_pdfWeights->GetEntry(entry);
                     // Only keep NNPDF weights
-                    lheWeights.insert(lheWeights.end(), pdfWeights->begin(), 
-                        pdfWeights->begin()+std::min(static_cast<size_t>(103), pdfWeights->size()));
-                }
-                else if (weight_info_ == 3) {
+                    lheWeights.insert(
+                        lheWeights.end(), pdfWeights->begin(),
+                        pdfWeights->begin() + std::min(static_cast<size_t>(103),
+                                                       pdfWeights->size()));
+                } else if (weight_info_ == 3) {
                     b_pdfWeights->GetEntry(entry);
-                    lheWeights.insert(lheWeights.end(), pdfWeights->begin(), pdfWeights->end());
+                    lheWeights.insert(lheWeights.end(), pdfWeights->begin(),
+                                      pdfWeights->end());
                 }
             }
         }
 
-        if (histMap1D_[{"MTWZ", channel_, Central}] != nullptr || histMap1D_[{"M3lMET", channel_, Central}] == nullptr) {
+        if (histMap1D_[{"MTWZ", channel_, Central}] != nullptr ||
+            histMap1D_[{"M3lMET", channel_, Central}] == nullptr) {
             TLorentzVector l1 = TLorentzVector();
             l1.SetPtEtaPhiM(l1Pt, l1Eta, l1Phi, 0);
             TLorentzVector l2 = TLorentzVector();
@@ -230,15 +271,14 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
             l3.SetPtEtaPhiM(l3Pt, l3Eta, l3Phi, 0);
             TLorentzVector met = TLorentzVector();
             met.SetPtEtaPhiM(MET, 0, type1_pfMETPhi, 0);
-            TLorentzVector zp4 = l1+l2;
-            TLorentzVector wp4 = l3+met;
-            TLorentzVector wzp4 = l1+l2+l3+met;
+            TLorentzVector zp4 = l1 + l2;
+            TLorentzVector wp4 = l3 + met;
+            TLorentzVector wzp4 = l1 + l2 + l3 + met;
             float sumEt = zp4.Et() + wp4.Et();
-            MtWZ = std::sqrt(sumEt*sumEt - wzp4.Pt()*wzp4.Pt());
-            M3lMET = (l1+l2+l3+met).M();
+            MtWZ = std::sqrt(sumEt * sumEt - wzp4.Pt() * wzp4.Pt());
+            M3lMET = (l1 + l2 + l3 + met).M();
         }
-    }
-    else if (isMC_) {
+    } else if (isMC_) {
         if (variation.first == jetEnergyScaleUp) {
             b_mjj_jesUp->GetEntry(entry);
             b_jetEta_jesUp->GetEntry(entry);
@@ -249,9 +289,8 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
             mjj = mjj_jesUp;
             jetEta = jetEta_jesUp;
             jetPt = jetPt_jesUp;
-            MET = type1_pfMETEt_jesUp*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == jetEnergyScaleDown) {
+            MET = type1_pfMETEt_jesUp * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == jetEnergyScaleDown) {
             b_mjj_jesDown->GetEntry(entry);
             b_jetEta_jesDown->GetEntry(entry);
             b_jetPt_jesDown->GetEntry(entry);
@@ -261,9 +300,8 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
             mjj = mjj_jesDown;
             jetEta = jetEta_jesDown;
             jetPt = jetPt_jesDown;
-            MET = type1_pfMETEt_jesDown*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == jetEnergyResolutionUp) {
+            MET = type1_pfMETEt_jesDown * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == jetEnergyResolutionUp) {
             b_mjj_jerUp->GetEntry(entry);
             b_jetEta_jerUp->GetEntry(entry);
             b_jetPt_jerUp->GetEntry(entry);
@@ -273,9 +311,8 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
             mjj = mjj_jerUp;
             jetEta = jetEta_jerUp;
             jetPt = jetPt_jerUp;
-            MET = type1_pfMETEt_jerUp*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == jetEnergyResolutionDown) {
+            MET = type1_pfMETEt_jerUp * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == jetEnergyResolutionDown) {
             b_mjj_jerDown->GetEntry(entry);
             b_jetEta_jerDown->GetEntry(entry);
             b_jetPt_jerDown->GetEntry(entry);
@@ -285,97 +322,105 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
             mjj = mjj_jerDown;
             jetEta = jetEta_jerDown;
             jetPt = jetPt_jerDown;
-            MET = type1_pfMETEt_jerDown*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == muonScaleUp || variation.first == muonScaleDown) {
-            if (channel_ == eee)
-                return;
+            MET = type1_pfMETEt_jerDown * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == muonScaleUp ||
+                   variation.first == muonScaleDown) {
+            if (channel_ == eee) return;
             if (channel_ == eem) {
                 float scaleUnc = GetMuonScaleUncertainty(l3Eta);
-                l3Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
-            }
-            else if (channel_ == emm) {
+                l3Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
+            } else if (channel_ == emm) {
                 float scaleUnc = GetMuonScaleUncertainty(l1Eta);
-                l1Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
+                l1Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
                 scaleUnc = GetMuonScaleUncertainty(l2Eta);
-                l2Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
-            }
-            else if (channel_ == mmm) {
+                l2Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
+            } else if (channel_ == mmm) {
                 float scaleUnc = GetMuonScaleUncertainty(l1Eta);
-                l1Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
+                l1Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
                 scaleUnc = GetMuonScaleUncertainty(l2Eta);
-                l2Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
+                l2Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
                 scaleUnc = GetMuonScaleUncertainty(l3Eta);
-                l3Pt *= variation.first == muonScaleUp ? (1+scaleUnc) : (1-scaleUnc);
+                l3Pt *= variation.first == muonScaleUp ? (1 + scaleUnc)
+                                                       : (1 - scaleUnc);
             }
             SetMasses();
-        }
-        else if (variation.first == electronScaleUp || variation.first == electronScaleDown) {
+        } else if (variation.first == electronScaleUp ||
+                   variation.first == electronScaleDown) {
             if (channel_ == eee) {
                 b_l1PtScaleCorrErr->GetEntry(entry);
                 b_l2PtScaleCorrErr->GetEntry(entry);
                 b_l3PtScaleCorrErr->GetEntry(entry);
-                l1Pt *= variation.first == electronScaleUp ? (1+l1PtScaleCorrErr) : (1-l1PtScaleCorrErr);
-                l2Pt *= variation.first == electronScaleUp ? (1+l2PtScaleCorrErr) : (1-l2PtScaleCorrErr);
-                l3Pt *= variation.first == electronScaleUp ? (1+l3PtScaleCorrErr) : (1-l3PtScaleCorrErr);
+                l1Pt *= variation.first == electronScaleUp
+                            ? (1 + l1PtScaleCorrErr)
+                            : (1 - l1PtScaleCorrErr);
+                l2Pt *= variation.first == electronScaleUp
+                            ? (1 + l2PtScaleCorrErr)
+                            : (1 - l2PtScaleCorrErr);
+                l3Pt *= variation.first == electronScaleUp
+                            ? (1 + l3PtScaleCorrErr)
+                            : (1 - l3PtScaleCorrErr);
             }
             if (channel_ == eem) {
                 b_l1PtScaleCorrErr->GetEntry(entry);
                 b_l2PtScaleCorrErr->GetEntry(entry);
-                l1Pt *= variation.first == electronScaleUp ? (1+l1PtScaleCorrErr) : (1-l1PtScaleCorrErr);
-                l2Pt *= variation.first == electronScaleUp ? (1+l2PtScaleCorrErr) : (1-l2PtScaleCorrErr);
-            }
-            else if (channel_ == emm) {
+                l1Pt *= variation.first == electronScaleUp
+                            ? (1 + l1PtScaleCorrErr)
+                            : (1 - l1PtScaleCorrErr);
+                l2Pt *= variation.first == electronScaleUp
+                            ? (1 + l2PtScaleCorrErr)
+                            : (1 - l2PtScaleCorrErr);
+            } else if (channel_ == emm) {
                 b_l3PtScaleCorrErr->GetEntry(entry);
-                l3Pt *= variation.first == electronScaleUp ? (1+l3PtScaleCorrErr) : (1-l3PtScaleCorrErr);
-            }
-            else if (channel_ == mmm)
+                l3Pt *= variation.first == electronScaleUp
+                            ? (1 + l3PtScaleCorrErr)
+                            : (1 - l3PtScaleCorrErr);
+            } else if (channel_ == mmm)
                 return;
             SetMasses();
-        }
-        else if (variation.first == metUnclusteredEnergyDown) {
+        } else if (variation.first == metUnclusteredEnergyDown) {
             b_type1_pfMETEt_unclusteredEnUp->GetEntry(entry);
             b_type1_pfMETEt_UncTool->GetEntry(entry);
-            MET = type1_pfMETEt_unclusteredEnUp*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == metUnclusteredEnergyDown) {
+            MET = type1_pfMETEt_unclusteredEnUp * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == metUnclusteredEnergyDown) {
             b_type1_pfMETEt_unclusteredEnDown->GetEntry(entry);
             b_type1_pfMETEt_UncTool->GetEntry(entry);
-            MET = type1_pfMETEt_unclusteredEnDown*MET/type1_pfMETEt_UncTool;
-        }
-        else if (variation.first == pileupUp) {
-            weight *= pileupSF_->Evaluate1D(nTruePU, ScaleFactor::ShiftUp)/pileupSF_->Evaluate1D(nTruePU);
-        }
-        else if (variation.first == pileupDown) {
-            weight *= pileupSF_->Evaluate1D(nTruePU, ScaleFactor::ShiftDown)/pileupSF_->Evaluate1D(nTruePU);
-        }
-        else if (variation.first == electronEfficiencyUp || variation.first == electronEfficiencyDown ||
-                    variation.first == muonEfficiencyUp || variation.first == muonEfficiencyDown) {
+            MET = type1_pfMETEt_unclusteredEnDown * MET / type1_pfMETEt_UncTool;
+        } else if (variation.first == pileupUp) {
+            weight *= pileupSF_->Evaluate1D(nTruePU, ScaleFactor::ShiftUp) /
+                      pileupSF_->Evaluate1D(nTruePU);
+        } else if (variation.first == pileupDown) {
+            weight *= pileupSF_->Evaluate1D(nTruePU, ScaleFactor::ShiftDown) /
+                      pileupSF_->Evaluate1D(nTruePU);
+        } else if (variation.first == electronEfficiencyUp ||
+                   variation.first == electronEfficiencyDown ||
+                   variation.first == muonEfficiencyUp ||
+                   variation.first == muonEfficiencyDown) {
             ShiftEfficiencies(variation.first);
         }
     }
 
     auto deltaRjj = [](std::vector<float>* jEta, std::vector<float>* jPhi) {
-        if (jEta->size() != jPhi->size() || jEta->size() < 2)
-            return -1.;
+        if (jEta->size() != jPhi->size() || jEta->size() < 2) return -1.;
         double etaDiff = jEta->at(0) - jEta->at(1);
         double phiDiff = jPhi->at(0) - jPhi->at(1);
-        return std::sqrt(etaDiff*etaDiff + phiDiff*phiDiff);
+        return std::sqrt(etaDiff * etaDiff + phiDiff * phiDiff);
     };
 
     auto deltaEtajj = [](std::vector<float>* jEta) {
-        if (jEta->size() < 2)
-            return -1.;
+        if (jEta->size() < 2) return -1.;
         double etaDiff = jEta->at(0) - jEta->at(1);
         return std::abs(etaDiff);
     };
 
     auto zeppenfeld = [](std::vector<float>* jEta, float objEta) {
-        if (jEta->size() < 2)
-            return -999.;
-        return objEta - 0.5*(jEta->at(1) + jEta->at(0));
+        if (jEta->size() < 2) return -999.;
+        return objEta - 0.5 * (jEta->at(1) + jEta->at(0));
     };
-
 
     dEtajj = deltaEtajj(jetEta);
     dRjj = deltaRjj(jetEta, jetPhi);
@@ -383,15 +428,12 @@ void WZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::str
 }
 
 bool WZSelector::PassesVBSBackgroundControlSelection() {
-    if (jetPt->size() != jetEta->size() || jetPt->size() < 2)
-        return false;
+    if (jetPt->size() != jetEta->size() || jetPt->size() < 2) return false;
 
     if (selection_ != VBSselection_Loose &&
-            selection_ != VBSselection_Loose_Full) {
-        if (jetPt->at(0) < 50 || jetPt->at(1) < 50)
-            return false;
-    }
-    else
+        selection_ != VBSselection_Loose_Full) {
+        if (jetPt->at(0) < 50 || jetPt->at(1) < 50) return false;
+    } else
         return (mjj > 100 && (mjj < 500 || dEtajj < 2.5));
 
     return (mjj > 100 && (mjj < 500 || dEtajj < 2.5 || std::abs(zep3l) > 2.5));
@@ -402,268 +444,329 @@ void WZSelector::ShiftEfficiencies(Systematic variation) {
     if (variation == electronEfficiencyDown || variation == muonEfficiencyDown)
         shift = ScaleFactor::Variation::ShiftDown;
 
-    if (channel_ == eee && (variation == electronEfficiencyUp || variation == electronEfficiencyDown)) {
-        weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-        weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-        weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-        weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-        weight *= eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-        weight *= eGsfSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-    }
-    else if (channel_ == eem) {
-        if (variation == electronEfficiencyUp || variation == electronEfficiencyDown) {
-            weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-            weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-            weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-            weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+    if (channel_ == eee && (variation == electronEfficiencyUp ||
+                            variation == electronEfficiencyDown)) {
+        weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                  eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+        weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                  eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+        weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                  eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                  eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        weight *= eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                  eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+        weight *= eGsfSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                  eGsfSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+    } else if (channel_ == eem) {
+        if (variation == electronEfficiencyUp ||
+            variation == electronEfficiencyDown) {
+            weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                      eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                      eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                      eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+            weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                      eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        } else if (variation == muonEfficiencyUp ||
+                   variation == muonEfficiencyDown) {
+            weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                      mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+            weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                      mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
         }
-        else if (variation == muonEfficiencyUp || variation == muonEfficiencyDown) {
-            weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-            weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+    } else if (channel_ == emm) {
+        if (variation == electronEfficiencyUp ||
+            variation == electronEfficiencyDown) {
+            weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                      eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                      eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+        } else if (variation == muonEfficiencyUp ||
+                   variation == muonEfficiencyDown) {
+            weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                      mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+            weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                      mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+            weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                      mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+            weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                      mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
         }
-    }
-    else if (channel_ == emm) {
-        if (variation == electronEfficiencyUp || variation == electronEfficiencyDown) {
-            weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-            weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-        }
-        else if (variation == muonEfficiencyUp || variation == muonEfficiencyDown) {
-            weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-            weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-            weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-            weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-        }
-    }
-    else if (channel_ == mmm && (variation == muonEfficiencyUp || variation == muonEfficiencyDown)) {
-        weight *= mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-        weight *= mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-        weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-        weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-        weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
-        weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift)/mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+    } else if (channel_ == mmm && (variation == muonEfficiencyUp ||
+                                   variation == muonEfficiencyDown)) {
+        weight *= mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                  mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+        weight *= mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt, shift) /
+                  mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+        weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                  mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt, shift) /
+                  mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        weight *= mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                  mIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
+        weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt, shift) /
+                  mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
     }
 }
 
 bool WZSelector::PassesVBSSelection(bool noBlind) {
-    if (!(isMC_ || noBlind))
-        return false;
-    if (jetPt->size() != jetEta->size() || jetPt->size() < 2)
-        return false;
+    if (!(isMC_ || noBlind)) return false;
+    if (jetPt->size() != jetEta->size() || jetPt->size() < 2) return false;
 
     // Use optimized point of pT(j1,j2) > 50 GeV
-    if (selection_ != VBSselection_Loose && 
-            selection_ != VBSselection_Loose_Full &&
-            selection_ != VBSBackgroundControl) { // &&
-        if (jetPt->at(0) < 50 || jetPt->at(1) < 50)
-            return false;
-    }
-    else if (jetPt->at(0) < 40 || jetPt->at(1) < 40)
+    if (selection_ != VBSselection_Loose &&
+        selection_ != VBSselection_Loose_Full &&
+        selection_ != VBSBackgroundControl) {  // &&
+        if (jetPt->at(0) < 50 || jetPt->at(1) < 50) return false;
+    } else if (jetPt->at(0) < 40 || jetPt->at(1) < 40)
         return false;
     if (selection_ == VBSselection_Tight ||
-                selection_ == VBSselection_Tight_Full) { 
-        if (std::abs(zep3l) > 2.5)
-            return false;
+        selection_ == VBSselection_Tight_Full) {
+        if (std::abs(zep3l) > 2.5) return false;
         return mjj > 500 && dEtajj > 2.5;
     }
     // Background control
-    else if (selection_ == VBSBackgroundControl) { 
-        return ((mjj > 500 && dEtajj < 2.5) ||
-                (mjj < 500 && dEtajj > 2.5));
-    }
-    else if (selection_ == VBSBackgroundControlATLAS) { 
+    else if (selection_ == VBSBackgroundControl) {
+        return ((mjj > 500 && dEtajj < 2.5) || (mjj < 500 && dEtajj > 2.5));
+    } else if (selection_ == VBSBackgroundControlATLAS) {
         return jetPt->at(0) > 40 && jetPt->at(1) > 40 && mjj > 150 && mjj < 500;
-    }
-    else if (selection_ == VBSBackgroundControlLoose ||
-             selection_ == VBSBackgroundControlLoose_Full) { 
+    } else if (selection_ == VBSBackgroundControlLoose ||
+               selection_ == VBSBackgroundControlLoose_Full) {
         return PassesVBSBackgroundControlSelection();
     }
     return mjj > 500 && dEtajj > 2.5;
     // ATLAS
-    //return mjj > 150;
+    // return mjj > 150;
 }
 
 bool WZSelector::PassesFullWZSelection(Long64_t entry) {
-    if (ZMass > 106.1876 || ZMass < 76.1876)
-        return false;
-    if (l1Pt < 25 || l2Pt < 15 || l3Pt < 20)
-        return false;
-    if (Mass < 100)
-        return false;
-    if (MET < 30)
-        return false;
+    if (ZMass > 106.1876 || ZMass < 76.1876) return false;
+    if (l1Pt < 25 || l2Pt < 15 || l3Pt < 20) return false;
+    if (Mass < 100) return false;
+    if (MET < 30) return false;
 
-    //b_jetCSVv2->GetEntry(entry);
-    //for (const auto& jetCSVval : *jetCSVv2) {
+    // b_jetCSVv2->GetEntry(entry);
+    // for (const auto& jetCSVval : *jetCSVv2) {
     //    if (jetCSVval > 0.9535)
     //        return false;
     //}
-    //b_Zlep1_Wlep_Mass->GetEntry(entry);
-    //b_Zlep2_Wlep_Mass->GetEntry(entry);
-    //if (Zlep1_Wlep_Mass < 4 || Zlep2_Wlep_Mass < 4)
+    // b_Zlep1_Wlep_Mass->GetEntry(entry);
+    // b_Zlep2_Wlep_Mass->GetEntry(entry);
+    // if (Zlep1_Wlep_Mass < 4 || Zlep2_Wlep_Mass < 4)
     //    return false;
 
     return true;
 }
 
-bool WZSelector::PassesBaseSelection(Long64_t entry, bool tightLeps, Selection selection) { 
-    //if (!(Flag_BadChargedCandidateFilterPass
-    //        && Flag_HBHENoiseFilterPass 
-    //        && Flag_HBHENoiseIsoFilterPass 
+bool WZSelector::PassesBaseSelection(Long64_t entry, bool tightLeps,
+                                     Selection selection) {
+    // if (!(Flag_BadChargedCandidateFilterPass
+    //        && Flag_HBHENoiseFilterPass
+    //        && Flag_HBHENoiseIsoFilterPass
     //        && Flag_BadPFMuonFilterPass
-    //        && Flag_EcalDeadCellTriggerPrimitiveFilterPass 
-    //        && Flag_goodVerticesPass 
+    //        && Flag_EcalDeadCellTriggerPrimitiveFilterPass
+    //        && Flag_goodVerticesPass
     //        && Flag_globalTightHalo2016FilterPass
     //        && (isMC_ || Flag_eeBadScFilterPass
-    //            //&& !Flag_duplicateMuonsPass 
+    //            //&& !Flag_duplicateMuonsPass
     //            //&& !Flag_badMuonsPass)
     //            // No longer vetoing events failing these filters
     //            // (we trust the MET in ReMiniAOD)
     //        )
     //    )
-    //) 
+    //)
     //    return false;
-    if (!passesLeptonVeto)
-        return false;
+    if (!passesLeptonVeto) return false;
     if (applyFullSelection_ && !PassesFullWZSelection(entry))
         return false;
-    else if (selection == FakeRateSelectionLoose || selection == FakeRateSelectionTight) {
-        if (l1Pt < 25 || l2Pt < 15)
-            return false;
-        if (ZMass > 111.1876 || ZMass < 81.1876)
-            return false;
-        if (MET > 25)
-            return false;
-        if (l3MtToMET > 30)
-            return false;
-        if (!tightZLeptons())
-            return false;
-        if (selection == FakeRateSelectionLoose)
-            tightLeps = false;
-    }
-    else if ((selection == Inclusive2Jet || selection == Inclusive2Jet_Full) &&
-                (jetPt->size() < 2 || jetPt->at(0) < 50 || jetPt->at(1) < 50))
+    else if (selection == FakeRateSelectionLoose ||
+             selection == FakeRateSelectionTight) {
+        if (l1Pt < 25 || l2Pt < 15) return false;
+        if (ZMass > 111.1876 || ZMass < 81.1876) return false;
+        if (MET > 25) return false;
+        if (l3MtToMET > 30) return false;
+        if (!tightZLeptons()) return false;
+        if (selection == FakeRateSelectionLoose) tightLeps = false;
+    } else if ((selection == Inclusive2Jet ||
+                selection == Inclusive2Jet_Full) &&
+               (jetPt->size() < 2 || jetPt->at(0) < 50 || jetPt->at(1) < 50))
         return false;
-    
+
     if (tightLeps && !(zlep1IsTight() && zlep2IsTight() && lepton3IsTight()))
         return false;
-    //if (!IsGenMatched3l()) {
+    // if (!IsGenMatched3l()) {
     //    return false;
     //}
 
     return true;
 }
 
-void WZSelector::FillVBSHistograms(float weight, bool noBlind,
-        std::pair<Systematic, std::string> variation) { 
+void WZSelector::FillVBSHistograms(
+    float weight, bool noBlind, std::pair<Systematic, std::string> variation) {
     // JES/JER uncertainties
     // Need to separate check VBS cuts using JER/JES variations
-    SafeHistFill(histMap2D_, "mjj_etajj_2D", channel_, variation.first, 
-        mjj, dEtajj, weight*(isMC_ || noBlind || mjj < 500 || dEtajj < 2.5));
+    SafeHistFill(histMap2D_, "mjj_etajj_2D", channel_, variation.first, mjj,
+                 dEtajj,
+                 weight * (isMC_ || noBlind || mjj < 500 || dEtajj < 2.5));
     SafeHistFill(histMap1D_, "zep3l", channel_, variation.first, zep3l, weight);
-    SafeHistFill(histMap2D_, "mjj_dRjj_2D", channel_, variation.first, mjj, dRjj, weight*(isMC_ || noBlind || mjj < 500 || dEtajj < 2.5));
+    SafeHistFill(histMap2D_, "mjj_dRjj_2D", channel_, variation.first, mjj,
+                 dRjj,
+                 weight * (isMC_ || noBlind || mjj < 500 || dEtajj < 2.5));
 
-    SafeHistFill(histMap1D_, "mjj", channel_, variation.first, mjj, weight*(isMC_ || (mjj < 500) || noBlind));
-    SafeHistFill(histMap1D_, "dEtajj", channel_, variation.first, dEtajj, weight*(isMC_ || (dEtajj < 2.5) || noBlind));
-    SafeHistFill(histMap1D_, "dRjj", channel_, variation.first, dRjj, weight*(isMC_ || (dRjj < 2.5) || noBlind));
+    SafeHistFill(histMap1D_, "mjj", channel_, variation.first, mjj,
+                 weight * (isMC_ || (mjj < 500) || noBlind));
+    SafeHistFill(histMap1D_, "dEtajj", channel_, variation.first, dEtajj,
+                 weight * (isMC_ || (dEtajj < 2.5) || noBlind));
+    SafeHistFill(histMap1D_, "dRjj", channel_, variation.first, dRjj,
+                 weight * (isMC_ || (dRjj < 2.5) || noBlind));
 
     if (jetPt->size() > 0 && jetPt->size() == jetEta->size()) {
-        SafeHistFill(histMap1D_, "jetPt[0]", channel_, variation.first, jetPt->at(0), weight);
-        SafeHistFill(histMap1D_, "jetEta[0]", channel_, variation.first, jetEta->at(0), weight);
+        SafeHistFill(histMap1D_, "jetPt[0]", channel_, variation.first,
+                     jetPt->at(0), weight);
+        SafeHistFill(histMap1D_, "jetEta[0]", channel_, variation.first,
+                     jetEta->at(0), weight);
     }
     if (jetPt->size() > 1 && jetPt->size() == jetEta->size()) {
-        SafeHistFill(histMap1D_, "jetPt[1]", channel_, variation.first, jetPt->at(1), weight);
-        SafeHistFill(histMap1D_, "jetEta[1]", channel_, variation.first, jetEta->at(1), weight);
+        SafeHistFill(histMap1D_, "jetPt[1]", channel_, variation.first,
+                     jetPt->at(1), weight);
+        SafeHistFill(histMap1D_, "jetEta[1]", channel_, variation.first,
+                     jetEta->at(1), weight);
     }
     if (jetPt->size() > 2 && jetPt->size() == jetEta->size()) {
-        SafeHistFill(histMap1D_, "jetPt[2]", channel_, variation.first, jetPt->at(2), weight);
-        SafeHistFill(histMap1D_, "jetEta[2]", channel_, variation.first, jetEta->at(2), weight);
+        SafeHistFill(histMap1D_, "jetPt[2]", channel_, variation.first,
+                     jetPt->at(2), weight);
+        SafeHistFill(histMap1D_, "jetEta[2]", channel_, variation.first,
+                     jetEta->at(2), weight);
     }
-     
+
     if (jetEta->size() > 3)
-        SafeHistFill(histMap1D_, "zepj3", channel_, variation.first, jetEta->at(2) - 0.5*(jetEta->at(1) + jetEta->at(0)), weight);
-    
-    if (histMap1D_[{"jetEta12", channel_, variation.first}] != nullptr && jetEta->size() > 1) {
-        histMap1D_[{"jetEta12", channel_, variation.first}]->Fill(jetEta->at(0), weight);
-        histMap1D_[{"jetEta12", channel_, variation.first}]->Fill(jetEta->at(1), weight);
+        SafeHistFill(histMap1D_, "zepj3", channel_, variation.first,
+                     jetEta->at(2) - 0.5 * (jetEta->at(1) + jetEta->at(0)),
+                     weight);
+
+    if (histMap1D_[{"jetEta12", channel_, variation.first}] != nullptr &&
+        jetEta->size() > 1) {
+        histMap1D_[{"jetEta12", channel_, variation.first}]->Fill(jetEta->at(0),
+                                                                  weight);
+        histMap1D_[{"jetEta12", channel_, variation.first}]->Fill(jetEta->at(1),
+                                                                  weight);
     }
 }
 
-void WZSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void WZSelector::FillHistograms(Long64_t entry,
+                                std::pair<Systematic, std::string> variation) {
     bool noBlind = true;
-    if (!PassesBaseSelection(entry, true, selection_))
-        return;
-    //bool passesVBS = PassesVBSSelection(noBlind);
+    if (!PassesBaseSelection(entry, true, selection_)) return;
+    // bool passesVBS = PassesVBSSelection(noBlind);
     bool passesVBS = false;
 
-    //if (histMap1D_["backgroundControlYield", channel_, variation.first] != nullptr)
+    // if (histMap1D_["backgroundControlYield", channel_, variation.first] !=
+    // nullptr)
     //    if (PassesVBSBackgroundControlSelection())
-    //        histMap1D_["backgroundControlYield", channel_, variation.first]->Fill(1, weight);
+    //        histMap1D_["backgroundControlYield", channel_,
+    //        variation.first]->Fill(1, weight);
 
     if ((variation.first == Central || (doaQGC_ && isaQGC_)) && isMC_) {
         for (size_t i = 0; i < lheWeights.size(); i++) {
             if (PassesVBSBackgroundControlSelection())
-                SafeHistFill(weighthistMap1D_, "backgroundControlYield", channel_, variation.first, 1, i, lheWeights[i]/lheWeights[0]*weight);
-            if (isVBS_ && !passesVBS)
-                continue;
-            SafeHistFill(weighthistMap1D_, "yield", channel_, variation.first, 1, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "mjj", channel_, variation.first, mjj, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "m_l1l3", channel_, variation.first, Zlep1_Wlep_Mass, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "m_l2l3", channel_, variation.first, Zlep2_Wlep_Mass, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "Mass", channel_, variation.first, Mass, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "MTWZ", channel_, variation.first, MtWZ, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "M3lMET", channel_, variation.first, M3lMET, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "l1Pt", channel_, variation.first, l1Pt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "l2Pt", channel_, variation.first, l2Pt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "l3Pt", channel_, variation.first, l3Pt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "ZPt", channel_, variation.first, ZPt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "Pt", channel_, variation.first, ZPt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap1D_, "Mass", channel_, variation.first, ZPt, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap2D_, "mjj_etajj_2D", channel_, variation.first, mjj, dEtajj, i, lheWeights[i]/lheWeights[0]*weight);
-            SafeHistFill(weighthistMap2D_, "mjj_dRjj_2D", channel_, variation.first, mjj, dRjj, i, lheWeights[i]/lheWeights[0]*weight);
+                SafeHistFill(weighthistMap1D_, "backgroundControlYield",
+                             channel_, variation.first, 1, i,
+                             lheWeights[i] / lheWeights[0] * weight);
+            if (isVBS_ && !passesVBS) continue;
+            SafeHistFill(weighthistMap1D_, "yield", channel_, variation.first,
+                         1, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "mjj", channel_, variation.first,
+                         mjj, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "m_l1l3", channel_, variation.first,
+                         Zlep1_Wlep_Mass, i,
+                         lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "m_l2l3", channel_, variation.first,
+                         Zlep2_Wlep_Mass, i,
+                         lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "Mass", channel_, variation.first,
+                         Mass, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "MTWZ", channel_, variation.first,
+                         MtWZ, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "M3lMET", channel_, variation.first,
+                         M3lMET, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "l1Pt", channel_, variation.first,
+                         l1Pt, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "l2Pt", channel_, variation.first,
+                         l2Pt, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "l3Pt", channel_, variation.first,
+                         l3Pt, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "ZPt", channel_, variation.first,
+                         ZPt, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "Pt", channel_, variation.first, ZPt,
+                         i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap1D_, "Mass", channel_, variation.first,
+                         ZPt, i, lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap2D_, "mjj_etajj_2D", channel_,
+                         variation.first, mjj, dEtajj, i,
+                         lheWeights[i] / lheWeights[0] * weight);
+            SafeHistFill(weighthistMap2D_, "mjj_dRjj_2D", channel_,
+                         variation.first, mjj, dRjj, i,
+                         lheWeights[i] / lheWeights[0] * weight);
         }
     }
-    if (isVBS_ && !passesVBS)
-        return;
-    //FillVBSHistograms(weight, noBlind, variation);
+    if (isVBS_ && !passesVBS) return;
+    // FillVBSHistograms(weight, noBlind, variation);
 
     SafeHistFill(histMap1D_, "yield", channel_, variation.first, 1, weight);
-    SafeHistFill(histMap1D_, "Mass", channel_, variation.first, Mass, 
-        weight*(isMC_ || Mass < 400 || noBlind));
+    SafeHistFill(histMap1D_, "Mass", channel_, variation.first, Mass,
+                 weight * (isMC_ || Mass < 400 || noBlind));
     SafeHistFill(histMap1D_, "ZMass", channel_, variation.first, ZMass, weight);
-    SafeHistFill(histMap1D_, "Zlep1_Pt", channel_, variation.first, l1Pt, weight);
-    SafeHistFill(histMap1D_, "Zlep1_Eta", channel_, variation.first, l1Eta, weight);
-    SafeHistFill(histMap1D_, "Zlep1_Phi", channel_, variation.first, l1Phi, weight);
-    SafeHistFill(histMap1D_, "Zlep2_Pt", channel_, variation.first, l2Pt, weight);
-    SafeHistFill(histMap1D_, "Zlep2_Eta", channel_, variation.first, l2Eta, weight);
-    SafeHistFill(histMap1D_, "Zlep2_Phi", channel_, variation.first, l2Phi, weight);
-    SafeHistFill(histMap1D_, "Wlep_Pt", channel_, variation.first, l3Pt, weight);
-    SafeHistFill(histMap1D_, "Wlep_Eta", channel_, variation.first, l3Eta, weight);
-    SafeHistFill(histMap1D_, "Wlep_Phi", channel_, variation.first, l3Phi, weight);
+    SafeHistFill(histMap1D_, "Zlep1_Pt", channel_, variation.first, l1Pt,
+                 weight);
+    SafeHistFill(histMap1D_, "Zlep1_Eta", channel_, variation.first, l1Eta,
+                 weight);
+    SafeHistFill(histMap1D_, "Zlep1_Phi", channel_, variation.first, l1Phi,
+                 weight);
+    SafeHistFill(histMap1D_, "Zlep2_Pt", channel_, variation.first, l2Pt,
+                 weight);
+    SafeHistFill(histMap1D_, "Zlep2_Eta", channel_, variation.first, l2Eta,
+                 weight);
+    SafeHistFill(histMap1D_, "Zlep2_Phi", channel_, variation.first, l2Phi,
+                 weight);
+    SafeHistFill(histMap1D_, "Wlep_Pt", channel_, variation.first, l3Pt,
+                 weight);
+    SafeHistFill(histMap1D_, "Wlep_Eta", channel_, variation.first, l3Eta,
+                 weight);
+    SafeHistFill(histMap1D_, "Wlep_Phi", channel_, variation.first, l3Phi,
+                 weight);
     SafeHistFill(histMap1D_, "MET", channel_, variation.first, MET, weight);
     // Just doing what works for now
     return;
-    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jetPt->size(), weight);
-    SafeHistFill(histMap1D_, "m_l1l3", channel_, variation.first, Zlep1_Wlep_Mass, weight);
-    SafeHistFill(histMap1D_, "m_l2l3", channel_, variation.first, Zlep2_Wlep_Mass, weight);
+    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jetPt->size(),
+                 weight);
+    SafeHistFill(histMap1D_, "m_l1l3", channel_, variation.first,
+                 Zlep1_Wlep_Mass, weight);
+    SafeHistFill(histMap1D_, "m_l2l3", channel_, variation.first,
+                 Zlep2_Wlep_Mass, weight);
     SafeHistFill(histMap1D_, "ZPhi", channel_, variation.first, ZPhi, weight);
     SafeHistFill(histMap1D_, "ZEta", channel_, variation.first, ZEta, weight);
-    SafeHistFill(histMap1D_, "MtW", channel_, variation.first, l3MtToMET, weight);
+    SafeHistFill(histMap1D_, "MtW", channel_, variation.first, l3MtToMET,
+                 weight);
     SafeHistFill(histMap1D_, "Eta", channel_, variation.first, Eta, weight);
 
     if (histMap1D_[{"dR_lW_Z", channel_, variation.first}] != nullptr) {
         float dPhi_lW_Z = ZPhi - l3Phi;
         float dEta_lW_Z = ZEta - l3Eta;
-        float dR_lW_Z = std::sqrt(dPhi_lW_Z*dPhi_lW_Z + dEta_lW_Z*dEta_lW_Z);
-        histMap1D_[{"dR_lW_Z", channel_, variation.first}]->Fill(dR_lW_Z, weight);
+        float dR_lW_Z =
+            std::sqrt(dPhi_lW_Z * dPhi_lW_Z + dEta_lW_Z * dEta_lW_Z);
+        histMap1D_[{"dR_lW_Z", channel_, variation.first}]->Fill(dR_lW_Z,
+                                                                 weight);
     }
     if (histMap1D_[{"nJetCSVv2T", channel_, variation.first}] != nullptr) {
         b_jetCSVv2->GetEntry(entry);
         unsigned int bjets = 0;
         for (const auto& jetCSVval : *jetCSVv2) {
-            if (jetCSVval > 0.9535)
-                bjets++;
+            if (jetCSVval > 0.9535) bjets++;
         }
-        histMap1D_[{"nJetCSVv2T", channel_, variation.first}]->Fill(bjets, weight);
+        histMap1D_[{"nJetCSVv2T", channel_, variation.first}]->Fill(bjets,
+                                                                    weight);
     }
     if (histMap1D_[{"Pt", channel_, variation.first}] != nullptr) {
         b_Pt->GetEntry(entry);
@@ -678,25 +781,27 @@ void WZSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::strin
         histMap1D_[{"ZPt", channel_, variation.first}]->Fill(ZPt, weight);
     }
 
-    SafeHistFill(histMap1D_, "MTWZ", channel_, variation.first, MtWZ, weight*(isMC_ || MtWZ < 300 || noBlind));
-    SafeHistFill(histMap1D_, "M3lMET", channel_, variation.first, M3lMET, weight*(isMC_ || M3lMET < 300 || noBlind));
+    SafeHistFill(histMap1D_, "MTWZ", channel_, variation.first, MtWZ,
+                 weight * (isMC_ || MtWZ < 300 || noBlind));
+    SafeHistFill(histMap1D_, "M3lMET", channel_, variation.first, M3lMET,
+                 weight * (isMC_ || M3lMET < 300 || noBlind));
     if (isMC_)
-        SafeHistFill(histMap1D_, "nTruePU", channel_, variation.first, nTruePU, weight);
+        SafeHistFill(histMap1D_, "nTruePU", channel_, variation.first, nTruePU,
+                     weight);
 }
 
-void WZSelector::SetupNewDirectory()
-{
+void WZSelector::SetupNewDirectory() {
     SelectorBase::SetupNewDirectory();
     isaQGC_ = name_.find("aqgc") != std::string::npos;
-    applyFullSelection_ = (selection_ == VBSselection_Loose_Full ||
-                      selection_ == VBSselection_Tight_Full || 
-                      selection_ == VBSselection_NoZeppenfeld_Full || 
-                      selection_ == Inclusive2Jet_Full ||
-                      selection_ == Wselection_Full ||
-                      selection_ == VBSBackgroundControl_Full ||
-                      selection_ == VBSBackgroundControlLoose_Full);
-    //doSystematics_ = applyFullSelection_;
-    //doSystematics_ = false;
-    
-    InitializeHistogramsFromConfig();   
+    applyFullSelection_ =
+        (selection_ == VBSselection_Loose_Full ||
+         selection_ == VBSselection_Tight_Full ||
+         selection_ == VBSselection_NoZeppenfeld_Full ||
+         selection_ == Inclusive2Jet_Full || selection_ == Wselection_Full ||
+         selection_ == VBSBackgroundControl_Full ||
+         selection_ == VBSBackgroundControlLoose_Full);
+    // doSystematics_ = applyFullSelection_;
+    // doSystematics_ = false;
+
+    InitializeHistogramsFromConfig();
 }

--- a/src/WZSelectorBase.cc
+++ b/src/WZSelectorBase.cc
@@ -1,65 +1,62 @@
 #include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
-#include "TLorentzVector.h"
 #include <TStyle.h>
 #include <regex>
+#include "TLorentzVector.h"
 #include "TParameter.h"
 
 // This is very WZ specific and should really be improved or likely removed
 std::string WZSelectorBase::GetNameFromFile() {
-    std::regex expr = std::regex("201[0-9]-[0-9][0-9]-[0-9][0-9]-(.*)-WZxsec2016");
+    std::regex expr =
+        std::regex("201[0-9]-[0-9][0-9]-[0-9][0-9]-(.*)-WZxsec2016");
     std::smatch matches;
-    std::string fileName = fChain->GetTree()->GetDirectory()->GetFile()->GetName(); 
+    std::string fileName =
+        fChain->GetTree()->GetDirectory()->GetFile()->GetName();
 
     std::regex_search(fileName, matches, expr);
     return std::string(matches.str(1));
 }
 
 void WZSelectorBase::SetScaleFactors() {
-    pileupSF_ = (ScaleFactor *) GetInputList()->FindObject("pileupSF");
-    if (pileupSF_ == nullptr ) 
+    pileupSF_ = (ScaleFactor*)GetInputList()->FindObject("pileupSF");
+    if (pileupSF_ == nullptr)
         std::invalid_argument("Must pass pileup weights SF");
-    eIdSF_ = (ScaleFactor *) GetInputList()->FindObject("electronTightIdSF");
-    if (eIdSF_ == nullptr ) 
-        std::invalid_argument("Must pass electron ID SF");
-    eGsfSF_ = (ScaleFactor *) GetInputList()->FindObject("electronGsfSF");
-    if (eGsfSF_ == nullptr ) 
-        std::invalid_argument("Must pass electron GSF SF");
-    mIdSF_ = (ScaleFactor *) GetInputList()->FindObject("muonTightIdSF");
-    if (mIdSF_ == nullptr ) 
-        std::invalid_argument("Must pass muon ID SF");
-    mIsoSF_ = (ScaleFactor *) GetInputList()->FindObject("muonIsoSF");
-    if (mIsoSF_ == nullptr ) 
-        std::invalid_argument("Must pass muon Iso SF");
+    eIdSF_ = (ScaleFactor*)GetInputList()->FindObject("electronTightIdSF");
+    if (eIdSF_ == nullptr) std::invalid_argument("Must pass electron ID SF");
+    eGsfSF_ = (ScaleFactor*)GetInputList()->FindObject("electronGsfSF");
+    if (eGsfSF_ == nullptr) std::invalid_argument("Must pass electron GSF SF");
+    mIdSF_ = (ScaleFactor*)GetInputList()->FindObject("muonTightIdSF");
+    if (mIdSF_ == nullptr) std::invalid_argument("Must pass muon ID SF");
+    mIsoSF_ = (ScaleFactor*)GetInputList()->FindObject("muonIsoSF");
+    if (mIsoSF_ == nullptr) std::invalid_argument("Must pass muon Iso SF");
 
-    prefireEff_ = (TEfficiency*) GetInputList()->FindObject("prefireEfficiencyMap");
-    if (prefireEff_ == nullptr ) 
+    prefireEff_ =
+        (TEfficiency*)GetInputList()->FindObject("prefireEfficiencyMap");
+    if (prefireEff_ == nullptr)
         std::invalid_argument("Must pass prefiring efficiency map");
 }
 
-void WZSelectorBase::Init(TTree *tree)
-{
-    isVBS_ = (selection_ == VBSselection_Loose || 
-        selection_ == VBSselection_Loose_Full || 
-        selection_ == VBSselection_NoZeppenfeld || 
-        selection_ == VBSselection_NoZeppenfeld_Full || 
-        selection_ == VBSselection_Tight || 
-        selection_ == VBSselection_Tight_Full || 
-        selection_ == VBSBackgroundControl || 
-        selection_ == VBSBackgroundControl_Full || 
-        selection_ == VBSBackgroundControlATLAS || 
-        selection_ == VBSBackgroundControlLoose ||
-        selection_ == VBSBackgroundControlLoose_Full
-        );
+void WZSelectorBase::Init(TTree* tree) {
+    isVBS_ = (selection_ == VBSselection_Loose ||
+              selection_ == VBSselection_Loose_Full ||
+              selection_ == VBSselection_NoZeppenfeld ||
+              selection_ == VBSselection_NoZeppenfeld_Full ||
+              selection_ == VBSselection_Tight ||
+              selection_ == VBSselection_Tight_Full ||
+              selection_ == VBSBackgroundControl ||
+              selection_ == VBSBackgroundControl_Full ||
+              selection_ == VBSBackgroundControlATLAS ||
+              selection_ == VBSBackgroundControlLoose ||
+              selection_ == VBSBackgroundControlLoose_Full);
 
     allChannels_ = {{eee, "eee"}, {eem, "eem"}, {emm, "emm"}, {mmm, "mmm"}};
 
-    if (isMC_){
+    if (isMC_) {
         isNonpromptMC_ = false;
         isZgamma_ = false;
-        if (std::find(nonprompt3l_.begin(), nonprompt3l_.end(), name_) != nonprompt3l_.end()) {
+        if (std::find(nonprompt3l_.begin(), nonprompt3l_.end(), name_) !=
+            nonprompt3l_.end()) {
             isNonpromptMC_ = true;
-        }
-        else if (name_ == "zg") {
+        } else if (name_ == "zg") {
             isZgamma_ = true;
         }
     }
@@ -70,11 +67,10 @@ void WZSelectorBase::Init(TTree *tree)
 
 void WZSelectorBase::SetBranchesUWVV() {
     b.CleanUp();
-    if (isMC_){
+    if (isMC_) {
         b.SetBranch("genWeight", genWeight);
         b.SetBranch("nTruePU", nTruePU);
-    }
-    else {
+    } else {
         b.SetBranch("Flag_duplicateMuonsPass", Flag_duplicateMuonsPass);
         b.SetBranch("Flag_badMuonsPass", Flag_badMuonsPass);
     }
@@ -109,8 +105,7 @@ void WZSelectorBase::SetBranchesUWVV() {
             b.SetBranch("e2GenPt", l2GenPt);
             b.SetBranch("e3GenPt", l3GenPt);
         }
-    }
-    else if (channel_ == eem) {
+    } else if (channel_ == eem) {
         b.SetBranch("e1IsCBVIDTight", l1IsTight);
         b.SetBranch("e2IsCBVIDTight", l2IsTight);
         b.SetBranch("mIsWZTight", l3IsTight);
@@ -139,8 +134,7 @@ void WZSelectorBase::SetBranchesUWVV() {
             b.SetBranch("e1GenPt", l1GenPt);
             b.SetBranch("e2GenPt", l2GenPt);
         }
-    }
-    else if (channel_ == emm) {
+    } else if (channel_ == emm) {
         b.SetBranch("eIsCBVIDTight", l3IsTight);
         b.SetBranch("m1IsWZTight", l1IsTight);
         b.SetBranch("m2IsWZTight", l2IsTight);
@@ -169,8 +163,7 @@ void WZSelectorBase::SetBranchesUWVV() {
             b.SetBranch("m1GenPt", l1GenPt);
             b.SetBranch("m2GenPt", l2GenPt);
         }
-    }
-    else if (channel_ == mmm) {
+    } else if (channel_ == mmm) {
         b.SetBranch("m1IsWZTight", l1IsTight);
         b.SetBranch("m2IsWZTight", l2IsTight);
         b.SetBranch("m3IsWZTight", l3IsTight);
@@ -208,14 +201,17 @@ void WZSelectorBase::SetBranchesUWVV() {
     b.SetBranch("nCBVIDVetoElec", nCBVIDVetoElec);
     b.SetBranch("nWZTightMuon", nWZTightMuon);
     b.SetBranch("nWZMediumMuon", nWZMediumMuon);
-    b.SetBranch("Flag_BadChargedCandidateFilterPass", Flag_BadChargedCandidateFilterPass);
+    b.SetBranch("Flag_BadChargedCandidateFilterPass",
+                Flag_BadChargedCandidateFilterPass);
     b.SetBranch("Flag_BadPFMuonFilterPass", Flag_BadPFMuonFilterPass);
     b.SetBranch("Flag_HBHENoiseFilterPass", Flag_HBHENoiseFilterPass);
     b.SetBranch("Flag_HBHENoiseIsoFilterPass", Flag_HBHENoiseIsoFilterPass);
-    b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilterPass", Flag_EcalDeadCellTriggerPrimitiveFilterPass);
+    b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilterPass",
+                Flag_EcalDeadCellTriggerPrimitiveFilterPass);
     b.SetBranch("Flag_goodVerticesPass", Flag_goodVerticesPass);
     b.SetBranch("Flag_eeBadScFilterPass", Flag_eeBadScFilterPass);
-    b.SetBranch("Flag_globalTightHalo2016FilterPass", Flag_globalTightHalo2016FilterPass);
+    b.SetBranch("Flag_globalTightHalo2016FilterPass",
+                Flag_globalTightHalo2016FilterPass);
 }
 
 void WZSelectorBase::SetBranchesNanoAOD() {
@@ -231,7 +227,7 @@ void WZSelectorBase::SetBranchesNanoAOD() {
     b.SetBranch("Muon_phi", Muon_phi);
     b.SetBranch("Muon_mass", Muon_mass);
     b.SetBranch("Muon_pfRelIso04_all", Muon_pfRelIso04_all);
-    //b.SetBranch("Electron_cutBased", Electron_cutBased);
+    // b.SetBranch("Electron_cutBased", Electron_cutBased);
     b.SetBranch("Electron_cutBased_Fall17_V1", Electron_cutBased);
     b.SetBranch("Electron_dxy", Electron_dxy);
     b.SetBranch("Electron_dz", Electron_dz);
@@ -244,38 +240,45 @@ void WZSelectorBase::SetBranchesNanoAOD() {
     b.SetBranch("Electron_charge", Electron_charge);
     b.SetBranch("Muon_charge", Muon_charge);
     if (isMC_) {
-        //b.SetBranch("e1GenPt", l1GenPt);
-        //b.SetBranch("e2GenPt", l2GenPt);
-        //b.SetBranch("e3GenPt", l3GenPt);
+        // b.SetBranch("e1GenPt", l1GenPt);
+        // b.SetBranch("e2GenPt", l2GenPt);
+        // b.SetBranch("e3GenPt", l3GenPt);
         b.SetBranch("genWeight", genWeight);
         b.SetBranch("Pileup_nPU", numPU);
     }
-    //else {
+    // else {
     //    b.SetBranch("Flag_duplicateMuonsPass", Flag_duplicateMuonsPass);
     //    b.SetBranch("Flag_badMuonsPass", Flag_badMuonsPass);
     //}
-    //b.SetBranch("Flag_BadChargedCandidateFilterPass", Flag_BadChargedCandidateFilterPass);
-    //b.SetBranch("Flag_BadPFMuonFilterPass", Flag_BadPFMuonFilterPass);
-    //b.SetBranch("Flag_HBHENoiseFilterPass", Flag_HBHENoiseFilterPass);
-    //b.SetBranch("Flag_HBHENoiseIsoFilterPass", Flag_HBHENoiseIsoFilterPass);
-    //b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilterPass", Flag_EcalDeadCellTriggerPrimitiveFilterPass);
-    //b.SetBranch("Flag_goodVerticesPass", Flag_goodVerticesPass);
-    //b.SetBranch("Flag_eeBadScFilterPass", Flag_eeBadScFilterPass);
-    //b.SetBranch("Flag_globalTightHalo2016FilterPass", Flag_globalTightHalo2016FilterPass);
+    // b.SetBranch("Flag_BadChargedCandidateFilterPass",
+    // Flag_BadChargedCandidateFilterPass);
+    // b.SetBranch("Flag_BadPFMuonFilterPass", Flag_BadPFMuonFilterPass);
+    // b.SetBranch("Flag_HBHENoiseFilterPass", Flag_HBHENoiseFilterPass);
+    // b.SetBranch("Flag_HBHENoiseIsoFilterPass", Flag_HBHENoiseIsoFilterPass);
+    // b.SetBranch("Flag_EcalDeadCellTriggerPrimitiveFilterPass",
+    // Flag_EcalDeadCellTriggerPrimitiveFilterPass);
+    // b.SetBranch("Flag_goodVerticesPass", Flag_goodVerticesPass);
+    // b.SetBranch("Flag_eeBadScFilterPass", Flag_eeBadScFilterPass);
+    // b.SetBranch("Flag_globalTightHalo2016FilterPass",
+    // Flag_globalTightHalo2016FilterPass);
 }
 
-void WZSelectorBase::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void WZSelectorBase::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     b.SetEntry(entry);
     weight = 1;
 
     if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_) {
-        std::string message = "Found more electrons or muons than max read number.\n    Found ";
+        std::string message =
+            "Found more electrons or muons than max read number.\n    Found ";
         message += std::to_string(nElectron);
         message += " electrons.\n    Found ";
         message += std::to_string(nMuon);
         message += " Muons\n  --> Max read number was ";
         message += std::to_string(N_KEEP_MU_E_);
-        message += "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ to avoid this error.\n";
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ "
+            "to avoid this error.\n";
         throw std::domain_error(message);
     }
 
@@ -293,11 +296,11 @@ void WZSelectorBase::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, s
     l3Mass = 0;
 
     SetChannelAndIndicesNano();
-    if (channel_ != eee && channel_ != eem && channel_ != emm && channel_ != mmm) {
+    if (channel_ != eee && channel_ != eem && channel_ != emm &&
+        channel_ != mmm) {
         passesLeptonVeto = false;
         return;
-    }
-    else
+    } else
         passesLeptonVeto = true;
 
     SetGoodLeptonsFromNano();
@@ -307,9 +310,8 @@ void WZSelectorBase::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, s
     if (isMC_) {
         ApplyScaleFactors();
     }
-    //else {
+    // else {
     //}
-
 }
 
 void WZSelectorBase::SetLeptonVarsNano() {
@@ -320,15 +322,15 @@ void WZSelectorBase::SetLeptonVarsNano() {
     l1Pt = l1.pt();
     l1Eta = l1.eta();
     l1Phi = l1.phi();
-    l1Mass= l1.mass();
+    l1Mass = l1.mass();
     l2Pt = l2.pt();
     l2Eta = l2.eta();
     l2Phi = l2.phi();
-    l2Mass= l2.mass();
+    l2Mass = l2.mass();
     l3Pt = l3.pt();
     l3Eta = l3.eta();
     l3Phi = l3.phi();
-    l3Mass= l3.mass();
+    l3Mass = l3.mass();
 
     if (channel_ == eee) {
         size_t ie = looseElecIndices.at(0);
@@ -343,8 +345,7 @@ void WZSelectorBase::SetLeptonVarsNano() {
         l3IsTight = (Electron_cutBased[ie] == 4);
         l3PVDXY = Electron_dxy[ie];
         l3PVDZ = Electron_dz[ie];
-    }
-    else if (channel_ == eem) {
+    } else if (channel_ == eem) {
         size_t ie = looseElecIndices.at(0);
         l1IsTight = (Electron_cutBased[ie] == 4);
         l1PVDXY = Electron_dxy[ie];
@@ -355,8 +356,7 @@ void WZSelectorBase::SetLeptonVarsNano() {
         l2PVDZ = Electron_dz[ie];
         size_t imu = looseMuonIndices.at(0);
         l3IsTight = (Muon_tightId[imu] && Muon_pfRelIso04_all[imu] < 0.15);
-    }
-    else if (channel_ == emm) {
+    } else if (channel_ == emm) {
         size_t imu = looseMuonIndices.at(0);
         l1IsTight = (Muon_tightId[imu] && Muon_pfRelIso04_all[imu] < 0.15);
         l1PVDXY = Muon_dxy[imu];
@@ -369,8 +369,7 @@ void WZSelectorBase::SetLeptonVarsNano() {
         l3IsTight = (Electron_cutBased[ie] == 4);
         l3PVDXY = Electron_dxy[ie];
         l3PVDZ = Electron_dz[ie];
-     }
-     else if (channel_ == mmm) {
+    } else if (channel_ == mmm) {
         size_t imu = looseMuonIndices.at(0);
         l1IsTight = (Muon_tightId[imu] && Muon_pfRelIso04_all[imu] < 0.15);
         l1PVDXY = Muon_dxy[imu];
@@ -383,10 +382,11 @@ void WZSelectorBase::SetLeptonVarsNano() {
         l3IsTight = (Muon_tightId[imu] && Muon_pfRelIso04_all[imu] < 0.15);
         l3PVDXY = Muon_dxy[imu];
         l3PVDZ = Muon_dz[imu];
-     }
+    }
 }
 
-// Always ordered: 0 - Zlep1, 1 - Zlep2, 2 - Wlep (lep IDs are clear from channel)
+// Always ordered: 0 - Zlep1, 1 - Zlep2, 2 - Wlep (lep IDs are clear from
+// channel)
 void WZSelectorBase::SetGoodLeptonsFromNano() {
     leptons.clear();
     bool zee = (channel_ == eem || channel_ == eee);
@@ -395,20 +395,24 @@ void WZSelectorBase::SetGoodLeptonsFromNano() {
         throw std::length_error("Invalid lepton indices");
     }
     for (const auto& i : indices) {
-        auto lep = zee ?
-            LorentzVector(Electron_pt[i], Electron_eta[i], Electron_phi[i], Electron_mass[i]) :
-            LorentzVector(Muon_pt[i], Muon_eta[i], Muon_phi[i], Muon_mass[i]);
+        auto lep = zee ? LorentzVector(Electron_pt[i], Electron_eta[i],
+                                       Electron_phi[i], Electron_mass[i])
+                       : LorentzVector(Muon_pt[i], Muon_eta[i], Muon_phi[i],
+                                       Muon_mass[i]);
         leptons.push_back(lep);
     }
 
     if (channel_ == eem || channel_ == emm) {
-        auto& wIndices = (channel_ == eem) ? looseMuonIndices : looseElecIndices;
+        auto& wIndices =
+            (channel_ == eem) ? looseMuonIndices : looseElecIndices;
         if (wIndices.size() != 1)
             throw std::length_error("Invalid W lepton indices");
         size_t wi = wIndices.at(0);
-        auto wlep = (channel_ == eem) ?
-                LorentzVector(Muon_pt[wi], Muon_eta[wi], Muon_phi[wi], Muon_mass[wi]) :
-                LorentzVector(Electron_pt[wi], Electron_eta[wi], Electron_phi[wi], Electron_mass[wi]);
+        auto wlep = (channel_ == eem)
+                        ? LorentzVector(Muon_pt[wi], Muon_eta[wi], Muon_phi[wi],
+                                        Muon_mass[wi])
+                        : LorentzVector(Electron_pt[wi], Electron_eta[wi],
+                                        Electron_phi[wi], Electron_mass[wi]);
         leptons.push_back(wlep);
     }
 }
@@ -420,7 +424,7 @@ void WZSelectorBase::SetChannelAndIndicesNano() {
     nWZTightMuon = 0;
     nWZMediumMuon = 0;
 
-    //TODO: Embed these variables in the NanoSkims
+    // TODO: Embed these variables in the NanoSkims
     looseMuonIndices.clear();
     looseElecIndices.clear();
     for (size_t i = 0; i < nMuon; i++) {
@@ -436,8 +440,7 @@ void WZSelectorBase::SetChannelAndIndicesNano() {
             nCBVIDVetoElec++;
             looseElecIndices.push_back(i);
         }
-        if (Electron_cutBased[i] == 4)
-            nCBVIDTightElec++;
+        if (Electron_cutBased[i] == 4) nCBVIDTightElec++;
     }
 
     if (nWZMediumMuon == 0 && nCBVIDVetoElec == 3)
@@ -450,14 +453,16 @@ void WZSelectorBase::SetChannelAndIndicesNano() {
         channelName_ = "mmm";
     else
         channelName_ = "Unknown";
-    
-    //std::cout << "Channel " << channelName_ << " " << channel_ << " elecIndices " << looseElecIndices.size() 
+
+    // std::cout << "Channel " << channelName_ << " " << channel_ << "
+    // elecIndices " << looseElecIndices.size()
     //          << " muon indices " << looseMuonIndices.size() << std::endl;
 
     channel_ = channelMap_[channelName_];
 }
 
-void WZSelectorBase::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation){ 
+void WZSelectorBase::LoadBranchesUWVV(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     b.SetEntry(entry);
     weight = 1;
 
@@ -467,14 +472,15 @@ void WZSelectorBase::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std:
     // Veto on tight leptons
     // Make sure tight leptons also pass loose
     // passesLeptonVeto = nWZTightMuon + nCBVIDTightElec <= 3 &&
-    //                      (nWZMediumMuon + nCBVIDHLTSafeElec) >= (nWZTightMuon+nCBVIDTightElec);
+    //                      (nWZMediumMuon + nCBVIDHLTSafeElec) >=
+    //                      (nWZTightMuon+nCBVIDTightElec);
     // If tight isn't required to include loose
-    // passesLeptonVeto = std::abs(nWZMediumMuon + nCBVIDHLTSafeElec - (l1IsLoose +l2IsLoose +l3IsLoose)) < 0.1;
+    // passesLeptonVeto = std::abs(nWZMediumMuon + nCBVIDHLTSafeElec -
+    // (l1IsLoose +l2IsLoose +l3IsLoose)) < 0.1;
 
     // Veto on loose leptons
-    //passesLeptonVeto = (nWZMediumMuon + nCBVIDHLTSafeElec) == 3;
+    // passesLeptonVeto = (nWZMediumMuon + nCBVIDHLTSafeElec) == 3;
     passesLeptonVeto = (nWZMediumMuon + nCBVIDVetoElec) == 3;
- 
 }
 
 void WZSelectorBase::ApplyScaleFactors() {
@@ -490,8 +496,7 @@ void WZSelectorBase::ApplyScaleFactors() {
             weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
             weight *= eGsfSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
         }
-    }
-    else if (channel_ == eem) {
+    } else if (channel_ == eem) {
         if (eIdSF_ != nullptr) {
             weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
             weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
@@ -506,8 +511,7 @@ void WZSelectorBase::ApplyScaleFactors() {
         if (mIsoSF_ != nullptr) {
             weight *= mIsoSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
         }
-    }
-    else if (channel_ == emm) {
+    } else if (channel_ == emm) {
         if (eIdSF_ != nullptr) {
             weight *= eIdSF_->Evaluate2D(std::abs(l3Eta), l3Pt);
         }
@@ -522,8 +526,7 @@ void WZSelectorBase::ApplyScaleFactors() {
             weight *= mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
             weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
         }
-    }
-    else {
+    } else {
         if (mIdSF_ != nullptr) {
             weight *= mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
             weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
@@ -536,7 +539,7 @@ void WZSelectorBase::ApplyScaleFactors() {
         }
     }
     if (pileupSF_ != nullptr) {
-        //weight *= pileupSF_->Evaluate1D(numPU);
+        // weight *= pileupSF_->Evaluate1D(numPU);
         weight *= pileupSF_->Evaluate1D(nTruePU);
     }
 }
@@ -548,52 +551,52 @@ void WZSelectorBase::SetMasses() {
         leptons.push_back(LorentzVector(l3Pt, l3Eta, l3Phi, l3Mass));
     }
 
-    ZMass = (leptons.at(0)+leptons.at(1)).M();
-    Mass = (leptons.at(0)+leptons.at(1)+leptons.at(2)).M();
+    ZMass = (leptons.at(0) + leptons.at(1)).M();
+    Mass = (leptons.at(0) + leptons.at(1) + leptons.at(2)).M();
 }
 
 // Meant to be a wrapper for the tight ID just in case it changes
 // To be a function of multiple variables
 bool WZSelectorBase::zlep1IsTight() {
     bool l1IsE = (channel_ == eem || channel_ == eee);
-    if (l1IsE) { 
+    if (l1IsE) {
         // TODO: This should really be the supercluster eta, I think
         bool isEB = std::abs(l1Eta) > 1.479;
-        return l1IsTight && (
-            std::abs(l1PVDXY) < (isEB ? 0.05 : 0.1) && std::abs(l1PVDZ) < (isEB ? 0.1 : 0.2));
+        return l1IsTight && (std::abs(l1PVDXY) < (isEB ? 0.05 : 0.1) &&
+                             std::abs(l1PVDZ) < (isEB ? 0.1 : 0.2));
     }
-    return (l1IsTight && std::abs(l1PVDXY) < 0.02 && std::abs(l1PVDZ) < 0.1); 
+    return (l1IsTight && std::abs(l1PVDXY) < 0.02 && std::abs(l1PVDZ) < 0.1);
 }
 
 bool WZSelectorBase::zlep2IsTight() {
     bool l2IsE = (channel_ == eem || channel_ == eee);
-    if (l2IsE) { 
+    if (l2IsE) {
         // TODO: This should really be the supercluster eta, I think
         bool isEB = std::abs(l2Eta) > 1.479;
-        return l2IsTight && (
-            std::abs(l2PVDXY) < (isEB ? 0.05 : 0.1) && std::abs(l2PVDZ) < (isEB ? 0.1 : 0.2));
+        return l2IsTight && (std::abs(l2PVDXY) < (isEB ? 0.05 : 0.1) &&
+                             std::abs(l2PVDZ) < (isEB ? 0.1 : 0.2));
     }
-    return (l2IsTight && std::abs(l2PVDXY) < 0.02 && std::abs(l2PVDZ) < 0.1); 
+    return (l2IsTight && std::abs(l2PVDXY) < 0.02 && std::abs(l2PVDZ) < 0.1);
 }
 
 bool WZSelectorBase::tightZLeptons() {
-    return zlep1IsTight() && zlep2IsTight(); 
+    return zlep1IsTight() && zlep2IsTight();
 }
 
 bool WZSelectorBase::lepton3IsTight() {
     bool l3IsE = (channel_ == emm || channel_ == eee);
-    if (l3IsE) { 
+    if (l3IsE) {
         // TODO: This should really be the supercluster eta, I think
         bool isEB = std::abs(l3Eta) > 1.479;
-        return l3IsTight && (
-            std::abs(l3PVDXY) < (isEB ? 0.05 : 0.1) && std::abs(l3PVDZ) < (isEB ? 0.1 : 0.2));
+        return l3IsTight && (std::abs(l3PVDXY) < (isEB ? 0.05 : 0.1) &&
+                             std::abs(l3PVDZ) < (isEB ? 0.1 : 0.2));
     }
-    return (l3IsTight && std::abs(l3PVDXY) < 0.02 && std::abs(l3PVDZ) < 0.1); 
+    return (l3IsTight && std::abs(l3PVDXY) < 0.02 && std::abs(l3PVDZ) < 0.1);
 }
 
 bool WZSelectorBase::IsGenMatched3l() {
-    //return true;
-    return (!isMC_ || isNonpromptMC_ || 
-        (isZgamma_ && l1GenPt > 0 && l2GenPt > 0) ||
-        (l1GenPt > 0 && l2GenPt > 0 && l3GenPt > 0));
+    // return true;
+    return (!isMC_ || isNonpromptMC_ ||
+            (isZgamma_ && l1GenPt > 0 && l2GenPt > 0) ||
+            (l1GenPt > 0 && l2GenPt > 0 && l3GenPt > 0));
 }

--- a/src/ZGenSelector.cc
+++ b/src/ZGenSelector.cc
@@ -1,27 +1,30 @@
 #include "Analysis/VVAnalysis/interface/ZGenSelector.h"
-#include "DataFormats/Math/interface/LorentzVector.h"
 #include <TStyle.h>
 #include <regex>
+#include "DataFormats/Math/interface/LorentzVector.h"
 
-void ZGenSelector::Init(TTree *tree)
-{
+void ZGenSelector::Init(TTree* tree) {
     allChannels_ = {{ee, "ee"}, {mm, "mm"}};
     // Add CutFlow for Unknown to understand when channels aren't categorized
     histMap1D_[{"CutFlow", Unknown, Central}] = {};
-    std::vector<std::string> basehists1D = {"CutFlow", "ZMass", "yZ", "ptZ", "phiZ", "ptl1", "etal1", "phil1", "ptl2", "etal2", "phil2", 
-        "ptj1", "ptj2", "ptj3", "etaj1", "etaj2", "etaj3", "phij1", "phij2", "phij3", "nJets",
-        "MET", "HT",};
+    std::vector<std::string> basehists1D = {
+        "CutFlow", "ZMass", "yZ",    "ptZ",   "phiZ",  "ptl1", "etal1", "phil1",
+        "ptl2",    "etal2", "phil2", "ptj1",  "ptj2",  "ptj3", "etaj1", "etaj2",
+        "etaj3",   "phij1", "phij2", "phij3", "nJets", "MET",  "HT",
+    };
     hists1D_ = basehists1D;
-    //std::vector<std::string> partonicChans = {"uu_dd", "uubar_ddbar", "ug_dg", "ubarg_dbarg", "gg", "other"};
-    //for (auto& chan : partonicChans) {
+    // std::vector<std::string> partonicChans = {"uu_dd", "uubar_ddbar",
+    // "ug_dg", "ubarg_dbarg", "gg", "other"}; for (auto& chan : partonicChans) {
     //    for (auto& hist : basehists1D)
     //        hists1D_.push_back(chan + "_" + hist);
     //}
     systHists_ = hists1D_;
 
-    weighthists1D_ = {"CutFlow", "ZMass", "yZ", "ptZ", "phiZ", "ptl1", "etal1", "ptl2", "etal2", 
-        "ptj1", "ptj2", "ptj3", "etaj1", "etaj2", "etaj3", "nJets",
-        "MET", "HT", };
+    weighthists1D_ = {
+        "CutFlow", "ZMass", "yZ",    "ptZ",   "phiZ", "ptl1",
+        "etal1",   "ptl2",  "etal2", "ptj1",  "ptj2", "ptj3",
+        "etaj1",   "etaj2", "etaj3", "nJets", "MET",  "HT",
+    };
     nLeptons_ = 2;
 
     doSystematics_ = true;
@@ -45,16 +48,14 @@ void ZGenSelector::Init(TTree *tree)
     if (name_.find("nnlops") != std::string::npos) {
         MV_GEN_ = 80398.0;
         GAMMAV_GEN_ = 2088.720;
-    }
-    else if (name_.find("minnlo") != std::string::npos) {
+    } else if (name_.find("minnlo") != std::string::npos) {
         MV_GEN_ = 91153.48061918276;
         GAMMAV_GEN_ = 2494.2663787728243;
 
         if (name_.find("mZup") != std::string::npos) {
             MV_GEN_ = 91253.48061918276;
         }
-    }
-    else {
+    } else {
         MV_GEN_ = 80419.;
         GAMMAV_GEN_ = 2050;
     }
@@ -62,35 +63,35 @@ void ZGenSelector::Init(TTree *tree)
     NanoGenSelectorBase::Init(tree);
 }
 
-void ZGenSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void ZGenSelector::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     NanoGenSelectorBase::LoadBranchesNanoAOD(entry, variation);
 
     if (variation.first == Central)
         cenWeight = weight;
     else if (variation.first == LHEParticles) {
         ptVlhe = zCand.pt();
-        mVlhe = zCand.mass()*1000.;
-    }
-    else if (variation.first == mZShift10MeVUp)
-        weight = cenWeight*breitWignerWeight(10.);
+        mVlhe = zCand.mass() * 1000.;
+    } else if (variation.first == mZShift10MeVUp)
+        weight = cenWeight * breitWignerWeight(10.);
     else if (variation.first == mZShift10MeVDown)
-        weight = cenWeight*breitWignerWeight(-10.);
+        weight = cenWeight * breitWignerWeight(-10.);
     else if (variation.first == mZShift20MeVUp)
-        weight = cenWeight*breitWignerWeight(20.);
+        weight = cenWeight * breitWignerWeight(20.);
     else if (variation.first == mZShift20MeVDown)
-        weight = cenWeight*breitWignerWeight(-20.);
+        weight = cenWeight * breitWignerWeight(-20.);
     else if (variation.first == mZShift25MeVUp)
-        weight = cenWeight*breitWignerWeight(25.);
+        weight = cenWeight * breitWignerWeight(25.);
     else if (variation.first == mZShift25MeVDown)
-        weight = cenWeight*breitWignerWeight(-25.);
+        weight = cenWeight * breitWignerWeight(-25.);
     else if (variation.first == mZShift50MeVUp)
-        weight = cenWeight*breitWignerWeight(50.);
+        weight = cenWeight * breitWignerWeight(50.);
     else if (variation.first == mZShift50MeVDown)
-        weight = cenWeight*breitWignerWeight(-50.);
+        weight = cenWeight * breitWignerWeight(-50.);
     else if (variation.first == mZShift100MeVUp)
-        weight = cenWeight*breitWignerWeight(100.);
+        weight = cenWeight * breitWignerWeight(100.);
     else if (variation.first == mZShift100MeVDown)
-        weight = cenWeight*breitWignerWeight(-100.);
+        weight = cenWeight * breitWignerWeight(-100.);
 
     if (leptons.size() < 2) {
         channel_ = Unknown;
@@ -101,13 +102,11 @@ void ZGenSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std
         if (std::abs(leptons.at(0).pdgId()) == 11) {
             channel_ = ee;
             channelName_ = "ee";
-        }
-        else if (std::abs(leptons.at(0).pdgId()) == 13) {
+        } else if (std::abs(leptons.at(0).pdgId()) == 13) {
             channel_ = mm;
             channelName_ = "mm";
         }
-    }
-    else {
+    } else {
         channel_ = Unknown;
         channelName_ = "Unknown";
     }
@@ -118,162 +117,248 @@ void ZGenSelector::SetComposite() {
         zCand = leptons.at(0).polarP4() + leptons.at(1).polarP4();
 }
 
-void ZGenSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void ZGenSelector::FillHistograms(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     int step = 0;
     int failStep = 0;
 
     step++;
-    if (channel_ != mm && channel_ != ee) 
-        failStep = step;
+    if (channel_ != mm && channel_ != ee) failStep = step;
 
     auto lep1 = leptons.size() > 1 ? leptons.at(0) : reco::GenParticle();
     auto lep2 = leptons.size() > 1 ? leptons.at(1) : reco::GenParticle();
 
     step++;
-    if (zCand.mass() < 50.)
-        failStep = step;
+    if (zCand.mass() < 50.) failStep = step;
     step++;
-    if (lep1.pt() < 25. || lep2.pt() < 25.)
-        failStep = step;
+    if (lep1.pt() < 25. || lep2.pt() < 25.) failStep = step;
     step++;
     if (std::abs(lep1.eta()) > 2.5 || std::abs(lep2.eta()) > 2.5)
         failStep = step;
     step++;
-    if (zCand.mass() < 60. || zCand.mass() > 120.)
-        failStep = step;
+    if (zCand.mass() < 60. || zCand.mass() > 120.) failStep = step;
 
     for (int j = 0; j < (failStep == 0 ? step : failStep); j++) {
-        SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, j, weight);
-        //size_t nWeights = *nLHEScaleWeight;
-        //for (size_t i = 0; i < nWeights; i++) {
+        SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, j,
+                     weight);
+        // size_t nWeights = *nLHEScaleWeight;
+        // for (size_t i = 0; i < nWeights; i++) {
         //    float thweight = LHEScaleWeight[i];
         //    thweight *= weight;
-        //    SafeHistFill(weighthistMap1D_, "CutFlow", channel_, variation.first, j, i, thweight);
+        //    SafeHistFill(weighthistMap1D_, "CutFlow", channel_,
+        //    variation.first, j, i, thweight);
         //}
     }
-    if (doFiducial_ && failStep != 0)
-        return;
+    if (doFiducial_ && failStep != 0) return;
     if (variation.first == Central)
-        mcWeights_->Fill(weight/std::abs(refWeight));
+        mcWeights_->Fill(weight / std::abs(refWeight));
 
-    if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(), variation.first) != theoryVarSysts_.end()) {
-        size_t minimalWeights = *nLHEScaleWeight+nLHEScaleWeightAltSet1+nLHEUnknownWeight+nLHEUnknownWeightAltSet1;
-        size_t nWeights = variation.first == Central ? minimalWeights : minimalWeights+nLHEPdfWeight;
+    if (std::find(theoryVarSysts_.begin(), theoryVarSysts_.end(),
+                  variation.first) != theoryVarSysts_.end()) {
+        size_t minimalWeights = *nLHEScaleWeight + nLHEScaleWeightAltSet1 +
+                                nLHEUnknownWeight + nLHEUnknownWeightAltSet1;
+        size_t nWeights = variation.first == Central
+                              ? minimalWeights
+                              : minimalWeights + nLHEPdfWeight;
         for (size_t i = 0; i < nWeights; i++) {
             float thweight = 1;
             if (i < *nLHEScaleWeight)
                 thweight = LHEScaleWeight[i];
-            else if (i < *nLHEScaleWeight+nLHEScaleWeightAltSet1)
-                thweight = LHEScaleWeightAltSet1[i-*nLHEScaleWeight];
-            else if (i < minimalWeights-nLHEUnknownWeightAltSet1)
-                thweight = LHEUnknownWeight[i-minimalWeights+nLHEUnknownWeight+nLHEUnknownWeightAltSet1];
+            else if (i < *nLHEScaleWeight + nLHEScaleWeightAltSet1)
+                thweight = LHEScaleWeightAltSet1[i - *nLHEScaleWeight];
+            else if (i < minimalWeights - nLHEUnknownWeightAltSet1)
+                thweight =
+                    LHEUnknownWeight[i - minimalWeights + nLHEUnknownWeight +
+                                     nLHEUnknownWeightAltSet1];
             else if (i < minimalWeights)
-                thweight = LHEUnknownWeight[i-minimalWeights+nLHEUnknownWeightAltSet1];
-            else 
-                thweight = LHEPdfWeight[i-minimalWeights];
+                thweight = LHEUnknownWeight[i - minimalWeights +
+                                            nLHEUnknownWeightAltSet1];
+            else
+                thweight = LHEPdfWeight[i - minimalWeights];
 
             if (centralWeightIndex_ != -1)
                 thweight /= LHEScaleWeight.At(centralWeightIndex_);
 
-            if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) && ptVlhe > 3.) ||
-                    ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) && (ptVlhe < 3. || ptVlhe > 5.))  ||
-                    ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) && (ptVlhe < 5. || ptVlhe > 7.)) ||
-                    ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) && (ptVlhe < 7. || ptVlhe > 9.)) ||
-                    ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) && (ptVlhe < 9. || ptVlhe > 12.)) ||
-                    ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) && (ptVlhe < 12. || ptVlhe > 15.)) ||
-                    ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) && (ptVlhe < 15. || ptVlhe > 20.)) ||
-                    ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) && (ptVlhe < 20. || ptVlhe > 27.)) ||
-                    ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) && (ptVlhe < 27. || ptVlhe > 40.)) ||
-                    ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) && ptVlhe < 40. )) {
+            if (((variation.first == ptV0to3 ||
+                  variation.first == ptV0to3_lhe) &&
+                 ptVlhe > 3.) ||
+                ((variation.first == ptV3to5 ||
+                  variation.first == ptV3to5_lhe) &&
+                 (ptVlhe < 3. || ptVlhe > 5.)) ||
+                ((variation.first == ptV5to7 ||
+                  variation.first == ptV5to7_lhe) &&
+                 (ptVlhe < 5. || ptVlhe > 7.)) ||
+                ((variation.first == ptV7to9 ||
+                  variation.first == ptV7to9_lhe) &&
+                 (ptVlhe < 7. || ptVlhe > 9.)) ||
+                ((variation.first == ptV9to12 ||
+                  variation.first == ptV9to12_lhe) &&
+                 (ptVlhe < 9. || ptVlhe > 12.)) ||
+                ((variation.first == ptV12to15 ||
+                  variation.first == ptV12to15_lhe) &&
+                 (ptVlhe < 12. || ptVlhe > 15.)) ||
+                ((variation.first == ptV15to20 ||
+                  variation.first == ptV15to20_lhe) &&
+                 (ptVlhe < 15. || ptVlhe > 20.)) ||
+                ((variation.first == ptV20to27 ||
+                  variation.first == ptV20to27_lhe) &&
+                 (ptVlhe < 20. || ptVlhe > 27.)) ||
+                ((variation.first == ptV27to40 ||
+                  variation.first == ptV27to40_lhe) &&
+                 (ptVlhe < 27. || ptVlhe > 40.)) ||
+                ((variation.first == ptV40toInf ||
+                  variation.first == ptV40toInf_lhe) &&
+                 ptVlhe < 40.)) {
                 thweight = 1;
             }
 
             thweight *= weight;
-            SafeHistFill(weighthistMap1D_, "ZMass", channel_, variation.first, zCand.mass(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "yZ", channel_, variation.first, zCand.Rapidity(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "ptZ", channel_, variation.first, zCand.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "phiZ", channel_, variation.first, zCand.phi(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "ptl1", channel_, variation.first, lep1.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "etal1", channel_, variation.first, lep1.eta(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "phil1", channel_, variation.first, lep1.phi(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "ptl2", channel_, variation.first, lep2.pt(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "etal2", channel_, variation.first, lep2.eta(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "phil2", channel_, variation.first, lep2.phi(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "nJets", channel_, variation.first, jets.size(), i, thweight);
-            SafeHistFill(weighthistMap1D_, "MET", channel_, variation.first, genMet.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "ZMass", channel_, variation.first,
+                         zCand.mass(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "yZ", channel_, variation.first,
+                         zCand.Rapidity(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "ptZ", channel_, variation.first,
+                         zCand.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "phiZ", channel_, variation.first,
+                         zCand.phi(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "ptl1", channel_, variation.first,
+                         lep1.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "etal1", channel_, variation.first,
+                         lep1.eta(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "phil1", channel_, variation.first,
+                         lep1.phi(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "ptl2", channel_, variation.first,
+                         lep2.pt(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "etal2", channel_, variation.first,
+                         lep2.eta(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "phil2", channel_, variation.first,
+                         lep2.phi(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "nJets", channel_, variation.first,
+                         jets.size(), i, thweight);
+            SafeHistFill(weighthistMap1D_, "MET", channel_, variation.first,
+                         genMet.pt(), i, thweight);
         }
     }
-    if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) && ptVlhe > 3.) ||
-            ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) && (ptVlhe < 3. || ptVlhe > 5.))  ||
-            ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) && (ptVlhe < 5. || ptVlhe > 7.)) ||
-            ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) && (ptVlhe < 7. || ptVlhe > 9.)) ||
-            ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) && (ptVlhe < 9. || ptVlhe > 12.)) ||
-            ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) && (ptVlhe < 12. || ptVlhe > 15.)) ||
-            ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) && (ptVlhe < 15. || ptVlhe > 20.)) ||
-            ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) && (ptVlhe < 20. || ptVlhe > 27.)) ||
-            ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) && (ptVlhe < 27. || ptVlhe > 40.)) ||
-            ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) && ptVlhe < 40. )) {
+    if (((variation.first == ptV0to3 || variation.first == ptV0to3_lhe) &&
+         ptVlhe > 3.) ||
+        ((variation.first == ptV3to5 || variation.first == ptV3to5_lhe) &&
+         (ptVlhe < 3. || ptVlhe > 5.)) ||
+        ((variation.first == ptV5to7 || variation.first == ptV5to7_lhe) &&
+         (ptVlhe < 5. || ptVlhe > 7.)) ||
+        ((variation.first == ptV7to9 || variation.first == ptV7to9_lhe) &&
+         (ptVlhe < 7. || ptVlhe > 9.)) ||
+        ((variation.first == ptV9to12 || variation.first == ptV9to12_lhe) &&
+         (ptVlhe < 9. || ptVlhe > 12.)) ||
+        ((variation.first == ptV12to15 || variation.first == ptV12to15_lhe) &&
+         (ptVlhe < 12. || ptVlhe > 15.)) ||
+        ((variation.first == ptV15to20 || variation.first == ptV15to20_lhe) &&
+         (ptVlhe < 15. || ptVlhe > 20.)) ||
+        ((variation.first == ptV20to27 || variation.first == ptV20to27_lhe) &&
+         (ptVlhe < 20. || ptVlhe > 27.)) ||
+        ((variation.first == ptV27to40 || variation.first == ptV27to40_lhe) &&
+         (ptVlhe < 27. || ptVlhe > 40.)) ||
+        ((variation.first == ptV40toInf || variation.first == ptV40toInf_lhe) &&
+         ptVlhe < 40.)) {
         return;
     }
 
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
-    SafeHistFill(histMap1D_, "ZMass", channel_, variation.first, zCand.mass(), weight);
-    SafeHistFill(histMap1D_, "yZ", channel_, variation.first, zCand.Rapidity(), weight);
-    SafeHistFill(histMap1D_, "ptZ", channel_, variation.first, zCand.pt(), weight);
-    SafeHistFill(histMap1D_, "phiZ", channel_, variation.first, zCand.phi(), weight);
-    SafeHistFill(histMap1D_, "ptl1", channel_, variation.first, lep1.pt(), weight);
-    SafeHistFill(histMap1D_, "etal1", channel_, variation.first, lep1.eta(), weight);
-    SafeHistFill(histMap1D_, "phil1", channel_, variation.first, lep1.phi(), weight);
-    SafeHistFill(histMap1D_, "ptl2", channel_, variation.first, lep2.pt(), weight);
-    SafeHistFill(histMap1D_, "etal2", channel_, variation.first, lep2.eta(), weight);
-    SafeHistFill(histMap1D_, "phil2", channel_, variation.first, lep2.phi(), weight);
-    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jets.size(), weight);
-    SafeHistFill(histMap1D_, "MET", channel_, variation.first, genMet.pt(), weight);
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
+    SafeHistFill(histMap1D_, "ZMass", channel_, variation.first, zCand.mass(),
+                 weight);
+    SafeHistFill(histMap1D_, "yZ", channel_, variation.first, zCand.Rapidity(),
+                 weight);
+    SafeHistFill(histMap1D_, "ptZ", channel_, variation.first, zCand.pt(),
+                 weight);
+    SafeHistFill(histMap1D_, "phiZ", channel_, variation.first, zCand.phi(),
+                 weight);
+    SafeHistFill(histMap1D_, "ptl1", channel_, variation.first, lep1.pt(),
+                 weight);
+    SafeHistFill(histMap1D_, "etal1", channel_, variation.first, lep1.eta(),
+                 weight);
+    SafeHistFill(histMap1D_, "phil1", channel_, variation.first, lep1.phi(),
+                 weight);
+    SafeHistFill(histMap1D_, "ptl2", channel_, variation.first, lep2.pt(),
+                 weight);
+    SafeHistFill(histMap1D_, "etal2", channel_, variation.first, lep2.eta(),
+                 weight);
+    SafeHistFill(histMap1D_, "phil2", channel_, variation.first, lep2.phi(),
+                 weight);
+    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jets.size(),
+                 weight);
+    SafeHistFill(histMap1D_, "MET", channel_, variation.first, genMet.pt(),
+                 weight);
     SafeHistFill(histMap1D_, "HT", channel_, variation.first, ht, weight);
     for (size_t i = 1; i <= 3; i++) {
-        if (jets.size() >= i ) {
-            const auto& jet = jets.at(i-1);
-            SafeHistFill(histMap1D_, ("ptj"+std::to_string(i)).c_str(), channel_, variation.first, jet.pt(), weight);
-            SafeHistFill(histMap1D_, ("etaj"+std::to_string(i)).c_str(), channel_, variation.first, jet.eta(), weight);
-            SafeHistFill(histMap1D_, ("phij"+std::to_string(i)).c_str(), channel_, variation.first, jet.phi(), weight);
-        }  
+        if (jets.size() >= i) {
+            const auto& jet = jets.at(i - 1);
+            SafeHistFill(histMap1D_, ("ptj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.pt(), weight);
+            SafeHistFill(histMap1D_, ("etaj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.eta(), weight);
+            SafeHistFill(histMap1D_, ("phij" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.phi(), weight);
+        }
     }
-    
-    // Should check how slow this is. For now it's off 
+
+    // Should check how slow this is. For now it's off
     return;
 
     std::string partonicChan = "other";
-    if ((*Generator_id1 == 1 && *Generator_id2 == 1) || (*Generator_id1 == 2 && *Generator_id2 == 2))
+    if ((*Generator_id1 == 1 && *Generator_id2 == 1) ||
+        (*Generator_id1 == 2 && *Generator_id2 == 2))
         partonicChan = "uu_dd";
-    else if ((*Generator_id1 == 1 && *Generator_id2 == -1) || (*Generator_id1 == 2 && *Generator_id2 == -2))
+    else if ((*Generator_id1 == 1 && *Generator_id2 == -1) ||
+             (*Generator_id1 == 2 && *Generator_id2 == -2))
         partonicChan = "uubar_ddbar";
     else if (*Generator_id1 == 21 && *Generator_id2 == 21)
         partonicChan = "gg";
-    else if ((*Generator_id1 == 1 && *Generator_id2 == 21) || (*Generator_id1 == 21 && *Generator_id2 == 1) || 
-                (*Generator_id1 == 2 && *Generator_id2 == 21) || (*Generator_id1 == 21 && *Generator_id2 == 2))
+    else if ((*Generator_id1 == 1 && *Generator_id2 == 21) ||
+             (*Generator_id1 == 21 && *Generator_id2 == 1) ||
+             (*Generator_id1 == 2 && *Generator_id2 == 21) ||
+             (*Generator_id1 == 21 && *Generator_id2 == 2))
         partonicChan = "ug_dg";
-    else if ((*Generator_id1 == -1 && *Generator_id2 == 21) || (*Generator_id1 == 21 && *Generator_id2 == -1) || 
-                (*Generator_id1 == -2 && *Generator_id2 == 21) || (*Generator_id1 == 21 && *Generator_id2 == -2))
+    else if ((*Generator_id1 == -1 && *Generator_id2 == 21) ||
+             (*Generator_id1 == 21 && *Generator_id2 == -1) ||
+             (*Generator_id1 == -2 && *Generator_id2 == 21) ||
+             (*Generator_id1 == 21 && *Generator_id2 == -2))
         partonicChan = "ubarg_dbarg";
-    SafeHistFill(histMap1D_, (partonicChan+"_ZMass").c_str(), channel_, variation.first, zCand.mass(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_yZ").c_str(), channel_, variation.first, zCand.Rapidity(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_ptZ").c_str(), channel_, variation.first, zCand.pt(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_ptl1").c_str(), channel_, variation.first, lep1.pt(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_etal1").c_str(), channel_, variation.first, lep1.eta(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_phil1").c_str(), channel_, variation.first, lep1.phi(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_ptl2").c_str(), channel_, variation.first, lep2.pt(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_etal2").c_str(), channel_, variation.first, lep2.eta(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_phil2").c_str(), channel_, variation.first, lep2.phi(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_nJets").c_str(), channel_, variation.first, jets.size(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_MET").c_str(), channel_, variation.first, genMet.pt(), weight);
-    SafeHistFill(histMap1D_, (partonicChan+"_HT").c_str(), channel_, variation.first, ht, weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_ZMass").c_str(), channel_,
+                 variation.first, zCand.mass(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_yZ").c_str(), channel_,
+                 variation.first, zCand.Rapidity(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_ptZ").c_str(), channel_,
+                 variation.first, zCand.pt(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_ptl1").c_str(), channel_,
+                 variation.first, lep1.pt(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_etal1").c_str(), channel_,
+                 variation.first, lep1.eta(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_phil1").c_str(), channel_,
+                 variation.first, lep1.phi(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_ptl2").c_str(), channel_,
+                 variation.first, lep2.pt(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_etal2").c_str(), channel_,
+                 variation.first, lep2.eta(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_phil2").c_str(), channel_,
+                 variation.first, lep2.phi(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_nJets").c_str(), channel_,
+                 variation.first, jets.size(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_MET").c_str(), channel_,
+                 variation.first, genMet.pt(), weight);
+    SafeHistFill(histMap1D_, (partonicChan + "_HT").c_str(), channel_,
+                 variation.first, ht, weight);
     for (size_t i = 1; i <= 3; i++) {
-        if (jets.size() >= i ) {
-            const auto& jet = jets.at(i-1);
-            SafeHistFill(histMap1D_, (partonicChan+"_ptj"+std::to_string(i)).c_str(), channel_, variation.first, jet.pt(), weight);
-            SafeHistFill(histMap1D_, (partonicChan+"_etaj"+std::to_string(i)).c_str(), channel_, variation.first, jet.eta(), weight);
-            SafeHistFill(histMap1D_, (partonicChan+"_phij"+std::to_string(i)).c_str(), channel_, variation.first, jet.phi(), weight);
-        }  
+        if (jets.size() >= i) {
+            const auto& jet = jets.at(i - 1);
+            SafeHistFill(histMap1D_,
+                         (partonicChan + "_ptj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.pt(), weight);
+            SafeHistFill(histMap1D_,
+                         (partonicChan + "_etaj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.eta(), weight);
+            SafeHistFill(histMap1D_,
+                         (partonicChan + "_phij" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.phi(), weight);
+        }
     }
 }
-

--- a/src/ZSelector.cc
+++ b/src/ZSelector.cc
@@ -2,47 +2,45 @@
 #include <TStyle.h>
 #include <regex>
 
-void ZSelector::Init(TTree *tree)
-{
+void ZSelector::Init(TTree *tree) {
     allChannels_ = {{ee, "ee"}, {mm, "mm"}};
     // Add CutFlow for Unknown to understand when channels aren't categorized
     histMap1D_[{"CutFlow", Unknown, Central}] = {};
-    hists1D_ = {"CutFlow", "ZMass", "ZEta", "yZ", "ZPt", "ptl1", "etal1", "ptl2", "etal2",
-		"ptj1", "ptj2", "ptj3", "etaj1", "etaj2", "etaj3", "phij1", "phij2", "phij3", "nJets",
-		"MET",};
+    hists1D_ = {
+        "CutFlow", "ZMass", "ZEta",  "yZ",    "ZPt",   "ptl1",  "etal1",
+        "ptl2",    "etal2", "ptj1",  "ptj2",  "ptj3",  "etaj1", "etaj2",
+        "etaj3",   "phij1", "phij2", "phij3", "nJets", "MET",
+    };
 
     b.SetTree(tree);
     SelectorBase::Init(tree);
-    
+
     singleLepton_ = false;
     if (!isMC_ && name_.find("Single") != std::string::npos)
         singleLepton_ = true;
 }
 
 void ZSelector::SetScaleFactors() {
-    pileupSF_ = (ScaleFactor *) GetInputList()->FindObject("pileupSF");
-    if (pileupSF_ == nullptr ) 
+    pileupSF_ = (ScaleFactor *)GetInputList()->FindObject("pileupSF");
+    if (pileupSF_ == nullptr)
         std::invalid_argument("Must pass pileup weights SF");
-    eIdSF_ = (ScaleFactor *) GetInputList()->FindObject("electronTightIdSF");
-    if (eIdSF_ == nullptr ) 
-        std::invalid_argument("Must pass electron ID SF");
-    eGsfSF_ = (ScaleFactor *) GetInputList()->FindObject("electronGsfSF");
-    if (eGsfSF_ == nullptr ) 
-        std::invalid_argument("Must pass electron GSF SF");
-    mIdSF_ = (ScaleFactor *) GetInputList()->FindObject("muonTightIdSF");
-    if (mIdSF_ == nullptr ) 
-        std::invalid_argument("Must pass muon ID SF");
-    mIsoSF_ = (ScaleFactor *) GetInputList()->FindObject("muonIsoSF");
-    if (mIsoSF_ == nullptr ) 
-        std::invalid_argument("Must pass muon Iso SF");
+    eIdSF_ = (ScaleFactor *)GetInputList()->FindObject("electronTightIdSF");
+    if (eIdSF_ == nullptr) std::invalid_argument("Must pass electron ID SF");
+    eGsfSF_ = (ScaleFactor *)GetInputList()->FindObject("electronGsfSF");
+    if (eGsfSF_ == nullptr) std::invalid_argument("Must pass electron GSF SF");
+    mIdSF_ = (ScaleFactor *)GetInputList()->FindObject("muonTightIdSF");
+    if (mIdSF_ == nullptr) std::invalid_argument("Must pass muon ID SF");
+    mIsoSF_ = (ScaleFactor *)GetInputList()->FindObject("muonIsoSF");
+    if (mIsoSF_ == nullptr) std::invalid_argument("Must pass muon Iso SF");
 
-    prefireEff_ = (TEfficiency*) GetInputList()->FindObject("prefireEfficiencyMap");
-    if (prefireEff_ == nullptr ) 
+    prefireEff_ =
+        (TEfficiency *)GetInputList()->FindObject("prefireEfficiencyMap");
+    if (prefireEff_ == nullptr)
         std::invalid_argument("Must pass prefiring efficiency map");
 }
 
 void ZSelector::SetBranchesUWVV() {
-    if (isMC_){
+    if (isMC_) {
         fChain->SetBranchAddress("genWeight", &genWeight, &b_genWeight);
         fChain->SetBranchAddress("nTruePU", &nTruePU, &b_nTruePU);
     }
@@ -55,8 +53,7 @@ void ZSelector::SetBranchesUWVV() {
         fChain->SetBranchAddress("e2Pt", &l2Pt, &b_l2Pt);
         fChain->SetBranchAddress("e1Eta", &l1Eta, &b_l1Eta);
         fChain->SetBranchAddress("e2Eta", &l2Eta, &b_l2Eta);
-    }
-    else if (channel_ == mm) {
+    } else if (channel_ == mm) {
         fChain->SetBranchAddress("m1ZZTightID", &l1IsTight, &b_l1IsTight);
         fChain->SetBranchAddress("m2ZZTightID", &l2IsTight, &b_l2IsTight);
         fChain->SetBranchAddress("m1Pt", &l1Pt, &b_l1Pt);
@@ -66,11 +63,15 @@ void ZSelector::SetBranchesUWVV() {
     }
 
     fChain->SetBranchAddress("type1_pfMETEt", &MET, &b_MET);
-    fChain->SetBranchAddress("type1_pfMETPhi", &type1_pfMETPhi, &b_type1_pfMETPhi);
-    fChain->SetBranchAddress("nZZTightElec", &nCBVIDTightElec, &b_nCBVIDTightElec);
-    //fChain->SetBranchAddress("nCBVIDHLTSafeElec", &nCBVIDHLTSafeElec, &b_nCBVIDHLTSafeElec);
+    fChain->SetBranchAddress("type1_pfMETPhi", &type1_pfMETPhi,
+                             &b_type1_pfMETPhi);
+    fChain->SetBranchAddress("nZZTightElec", &nCBVIDTightElec,
+                             &b_nCBVIDTightElec);
+    // fChain->SetBranchAddress("nCBVIDHLTSafeElec", &nCBVIDHLTSafeElec,
+    // &b_nCBVIDHLTSafeElec);
     fChain->SetBranchAddress("nZZTightMu", &nTightIdMuon, &b_nTightIdMuon);
-    //fChain->SetBranchAddress("nWZMediumMuon", &nWZMediumMuon, &b_nWZMediumMuon);
+    // fChain->SetBranchAddress("nWZMediumMuon", &nWZMediumMuon,
+    // &b_nWZMediumMuon);
 }
 
 void ZSelector::SetBranchesNanoAOD() {
@@ -98,9 +99,10 @@ void ZSelector::SetBranchesNanoAOD() {
     b.SetBranch("MET_phi", type1_pfMETPhi);
     b.SetBranch("Electron_charge", Electron_charge);
     b.SetBranch("Muon_charge", Muon_charge);
-    //b.SetBranch("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL", Dimuon_Trigger);
+    // b.SetBranch("HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL", Dimuon_Trigger);
     b.SetBranch("HLT_IsoMu24", SingleMuon_Trigger);
-    //b.SetBranch("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ", Dielectron_Trigger);
+    // b.SetBranch("HLT_Ele17_Ele12_CaloIdL_TrackIdL_IsoVL_DZ",
+    // Dielectron_Trigger);
     b.SetBranch("HLT_Ele27_WPTight_Gsf", SingleElectron_Trigger);
     if (isMC_) {
         b.SetBranch("genWeight", genWeight);
@@ -108,29 +110,37 @@ void ZSelector::SetBranchesNanoAOD() {
     }
 }
 
-void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void ZSelector::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     weight = 1;
     b.SetEntry(entry);
-    
-    // You could resize the array per event to match the number number of muons/electrons read but
-    // it doesn't seem worth it to me. Just set to a high enough value
+
+    // You could resize the array per event to match the number number of
+    // muons/electrons read but it doesn't seem worth it to me. Just set to a
+    // high enough value
     if (nElectron > N_KEEP_MU_E_ || nMuon > N_KEEP_MU_E_) {
-        std::string message = "Found more electrons or muons than max read number.\n    Found ";
+        std::string message =
+            "Found more electrons or muons than max read number.\n    Found ";
         message += std::to_string(nElectron);
         message += " electrons.\n    Found ";
         message += std::to_string(nMuon);
         message += " Muons\n  --> Max read number was ";
         message += std::to_string(N_KEEP_MU_E_);
-        message += "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ to avoid this error.\n";
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_MU_E_ "
+            "to avoid this error.\n";
         throw std::domain_error(message);
     }
 
     if (nJet > N_KEEP_JET_) {
-        std::string message = "Found more jets than max read number.\n    Found ";
+        std::string message =
+            "Found more jets than max read number.\n    Found ";
         message += std::to_string(nJet);
         message += " particles\n  --> Max read number was ";
         message += std::to_string(N_KEEP_JET_);
-        message += "\nExiting because this can cause problems. Increase N_KEEP_JET_ to avoid this error.\n";
+        message +=
+            "\nExiting because this can cause problems. Increase N_KEEP_JET_ "
+            "to avoid this error.\n";
         throw std::domain_error(message);
     }
 
@@ -145,13 +155,15 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
     l2Mass = 0;
 
     // cut-based ID Fall17 V2 (0:fail, 1:veto, 2:loose, 3:medium, 4:tight)
-    nCBVIDTightElec = std::count(Electron_cutBased, Electron_cutBased+nElectron, 4);
-    nCBVIDVetoElec = std::count(Electron_cutBased, Electron_cutBased+nElectron, 1);
+    nCBVIDTightElec =
+        std::count(Electron_cutBased, Electron_cutBased + nElectron, 4);
+    nCBVIDVetoElec =
+        std::count(Electron_cutBased, Electron_cutBased + nElectron, 1);
     nTightIdMuon = 0;
     nMediumIdMuon = 0;
 
     for (size_t i = 0; i < nMuon; i++) {
-        //nMediumIdMuon += (Muon_mediumId[i] && Muon_pfRelIso04_all[i] < 0.15);
+        // nMediumIdMuon += (Muon_mediumId[i] && Muon_pfRelIso04_all[i] < 0.15);
         nMediumIdMuon += (Muon_mediumId[i] && Muon_pfRelIso04_all[i] < 0.15);
         nTightIdMuon += (Muon_tightId[i] && Muon_pfRelIso04_all[i] < 0.15);
     }
@@ -162,17 +174,15 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
     if (nTightIdMuon >= 2) {
         channel_ = mm;
         channelName_ = "mm";
-        if (!(Muon_mediumId[0] && Muon_pfRelIso04_all[0] < 0.15
-	      && Muon_mediumId[1] && Muon_pfRelIso04_all[1] < 0.15)) {
+        if (!(Muon_mediumId[0] && Muon_pfRelIso04_all[0] < 0.15 &&
+              Muon_mediumId[1] && Muon_pfRelIso04_all[1] < 0.15)) {
             for (size_t i = 0; i < nMuon; i++) {
-                if (Muon_mediumId[i])
-                    goodIndices.push_back(i);
+                if (Muon_mediumId[i]) goodIndices.push_back(i);
             }
             if (goodIndices.size() < 2) {
                 return;
             }
-        }
-        else 
+        } else
             goodIndices = {0, 1};
         if (Muon_charge[goodIndices[0]] != Muon_charge[goodIndices[1]]) {
             l1Pt = Muon_pt[goodIndices[0]];
@@ -183,24 +193,23 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
             l2Phi = Muon_phi[goodIndices[1]];
             l1Mass = Muon_mass[goodIndices[0]];
             l2Mass = Muon_mass[goodIndices[1]];
-            l1IsTight = (Muon_mediumId[goodIndices[0]] && (Muon_pfRelIso04_all[goodIndices[0]] < 0.15));
-            l2IsTight = (Muon_mediumId[goodIndices[1]] && (Muon_pfRelIso04_all[goodIndices[1]] < 0.15));
+            l1IsTight = (Muon_mediumId[goodIndices[0]] &&
+                         (Muon_pfRelIso04_all[goodIndices[0]] < 0.15));
+            l2IsTight = (Muon_mediumId[goodIndices[1]] &&
+                         (Muon_pfRelIso04_all[goodIndices[1]] < 0.15));
         }
-    }
-    else if (nCBVIDTightElec >= 2) {
+    } else if (nCBVIDTightElec >= 2) {
         channel_ = ee;
         channelName_ = "ee";
         if (!(Electron_cutBased[0] == 4 && Electron_cutBased[1] == 4)) {
             for (size_t i = 0; i < nElectron; i++) {
-                if (Electron_cutBased[i] == 4)
-                    goodIndices.push_back(i);
+                if (Electron_cutBased[i] == 4) goodIndices.push_back(i);
             }
-            if (goodIndices.size() < 2)
-                return;
-        }
-        else 
+            if (goodIndices.size() < 2) return;
+        } else
             goodIndices = {0, 1};
-        if (Electron_charge[goodIndices[0]] != Electron_charge[goodIndices[1]]) {
+        if (Electron_charge[goodIndices[0]] !=
+            Electron_charge[goodIndices[1]]) {
             l1Pt = Electron_pt[goodIndices[0]];
             l2Pt = Electron_pt[goodIndices[1]];
             l1Eta = Electron_eta[goodIndices[0]];
@@ -212,8 +221,7 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
             l1IsTight = (Electron_cutBased[goodIndices[0]] == 4);
             l2IsTight = (Electron_cutBased[goodIndices[1]] == 4);
         }
-    }
-    else {
+    } else {
         channel_ = Unknown;
         channelName_ = "Unknown";
     }
@@ -240,25 +248,24 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
         jet.SetEta(Jet_eta[i]);
         jet.SetPhi(Jet_phi[i]);
         jet.SetM(Jet_mass[i]);
-        if (jet.pt() > 30 && !helpers::overlapsCollection(jet, leptons, 0.4, leptons.size()))
+        if (jet.pt() > 30 &&
+            !helpers::overlapsCollection(jet, leptons, 0.4, leptons.size()))
             jets.push_back(jet);
-    } 
+    }
     SetComposite();
 
     if (isMC_) {
         weight = genWeight;
         ApplyScaleFactors();
-    }
-    else {
-        //TODO: add MET filters
+    } else {
+        // TODO: add MET filters
     }
 
-
-    //if (!singleLepton_)
+    // if (!singleLepton_)
     //    //passesTrigger = (Dimuon_Trigger || SingleMuon_Trigger ||
     //    //        Dielectron_Trigger || SingleElectron_Trigger);
     //    passesTrigger = (Dimuon_Trigger || SingleMuon_Trigger);
-    //else
+    // else
     //    passesTrigger = (!Dimuon_Trigger && SingleMuon_Trigger);
     //    //passesTrigger = ((!Dimuon_Trigger && SingleMuon_Trigger) ||
     //    //        (!Dielectron_Trigger && SingleElectron_Trigger));
@@ -267,7 +274,8 @@ void ZSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::s
     passesLeptonVeto = (nCBVIDTightElec == 2 || nTightIdMuon == 2);
 }
 
-void ZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation){ 
+void ZSelector::LoadBranchesUWVV(Long64_t entry,
+                                 std::pair<Systematic, std::string> variation) {
     weight = 1;
     b_l1Pt->GetEntry(entry);
     b_l2Pt->GetEntry(entry);
@@ -283,35 +291,34 @@ void ZSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::stri
     b_l2IsTight->GetEntry(entry);
     b_MET->GetEntry(entry);
     b_nCBVIDTightElec->GetEntry(entry);
-    b_nTightIdMuon ->GetEntry(entry);
-    
+    b_nTightIdMuon->GetEntry(entry);
+
     passesTrigger = true;
     passesLeptonVeto = (nCBVIDTightElec == 2 || nTightIdMuon == 2);
 }
 
 void ZSelector::ApplyScaleFactors() {
     if (channel_ == ee) {
-	if (eIdSF_ != nullptr) {
-	    weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-	    weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-	}
-	if (eGsfSF_ != nullptr) {
-	    weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-	    weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-	}
-    }
-    else if (channel_ == mm) {
-	if (mIdSF_ != nullptr) {
-	    weight *= mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-	    weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-	}
-	if (mIsoSF_ != nullptr) {
-	    weight *= mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
-	    weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
-	}
+        if (eIdSF_ != nullptr) {
+            weight *= eIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= eIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        }
+        if (eGsfSF_ != nullptr) {
+            weight *= eGsfSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= eGsfSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        }
+    } else if (channel_ == mm) {
+        if (mIdSF_ != nullptr) {
+            weight *= mIdSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= mIdSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        }
+        if (mIsoSF_ != nullptr) {
+            weight *= mIsoSF_->Evaluate2D(std::abs(l1Eta), l1Pt);
+            weight *= mIsoSF_->Evaluate2D(std::abs(l2Eta), l2Pt);
+        }
     }
     if (pileupSF_ != nullptr) {
-	weight *= pileupSF_->Evaluate1D(numPU);
+        weight *= pileupSF_->Evaluate1D(numPU);
     }
 }
 
@@ -319,7 +326,7 @@ void ZSelector::SetComposite() {
     if (l1Pt == 0. || l2Pt == 0.) {
         return;
     }
-    auto system = leptons.at(0)+leptons.at(1);
+    auto system = leptons.at(0) + leptons.at(1);
     ZMass = system.mass();
     ZPt = system.pt();
     ZEta = system.eta();
@@ -328,52 +335,49 @@ void ZSelector::SetComposite() {
 
 // Meant to be a wrapper for the tight ID just in case it changes
 // To be a function of multiple variables
-bool ZSelector::zlep1IsTight() {
-    return l1IsTight; 
-}
+bool ZSelector::zlep1IsTight() { return l1IsTight; }
 
-bool ZSelector::zlep2IsTight() {
-    return l2IsTight; 
-}
+bool ZSelector::zlep2IsTight() { return l2IsTight; }
 
-bool ZSelector::tightZLeptons() {
-    return zlep1IsTight() && zlep2IsTight(); 
-}
+bool ZSelector::tightZLeptons() { return zlep1IsTight() && zlep2IsTight(); }
 
-void ZSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
+void ZSelector::FillHistograms(Long64_t entry,
+                               std::pair<Systematic, std::string> variation) {
     int step = 0;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
+    if (channel_ != mm && channel_ != ee) return;
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
-    if (channel_ != mm && channel_ != ee) 
+    if (!passesTrigger) return;
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
+
+    if (channel_ == ee && (std::abs(l1Eta) > 2.4 || std::abs(l2Eta) > 2.4))
         return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
-
-    if (!passesTrigger)
+    else if (channel_ == mm && (std::abs(l1Eta) > 2.5 || std::abs(l2Eta) > 2.5))
         return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
-    if (channel_ == ee && (std::abs(l1Eta) > 2.4 || std::abs(l2Eta) > 2.4 ))
-	    return;
-    else if (channel_ == mm && (std::abs(l1Eta) > 2.5 || std::abs(l2Eta) > 2.5 ))
-        return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    if (l1Pt < 25 || l2Pt < 25) return;
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
-    if (l1Pt < 25 || l2Pt < 25)
-        return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    if (ZMass > 106.1876 || ZMass < 76.1876) return;
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
-    if (ZMass > 106.1876 || ZMass < 76.1876)
-        return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
-
-    //if (MET > 25)
+    // if (MET > 25)
     //    return;
-    //SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    // SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+    // weight);
 
-    if (!tightZLeptons())
-        return;
-    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++, weight);
+    if (!tightZLeptons()) return;
+    SafeHistFill(histMap1D_, "CutFlow", channel_, variation.first, step++,
+                 weight);
 
     SafeHistFill(histMap1D_, "ZMass", channel_, variation.first, ZMass, weight);
     SafeHistFill(histMap1D_, "ptl1", channel_, variation.first, l1Pt, weight);
@@ -383,15 +387,19 @@ void ZSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string
     SafeHistFill(histMap1D_, "ZEta", channel_, variation.first, ZEta, weight);
     SafeHistFill(histMap1D_, "yZ", channel_, variation.first, Zy, weight);
     SafeHistFill(histMap1D_, "ZPt", channel_, variation.first, ZPt, weight);
-    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jets.size(), weight);
+    SafeHistFill(histMap1D_, "nJets", channel_, variation.first, jets.size(),
+                 weight);
     SafeHistFill(histMap1D_, "MET", channel_, variation.first, MET, weight);
     for (size_t i = 1; i <= 3; i++) {
-        if (jets.size() >= i ) {
-            const auto& jet = jets.at(i-1);
-            SafeHistFill(histMap1D_, ("ptj"+std::to_string(i)).c_str(), channel_, variation.first, jet.pt(), weight);
-            SafeHistFill(histMap1D_, ("etaj"+std::to_string(i)).c_str(), channel_, variation.first, jet.eta(), weight);
-            SafeHistFill(histMap1D_, ("phij"+std::to_string(i)).c_str(), channel_, variation.first, jet.phi(), weight);
-        }  
+        if (jets.size() >= i) {
+            const auto &jet = jets.at(i - 1);
+            SafeHistFill(histMap1D_, ("ptj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.pt(), weight);
+            SafeHistFill(histMap1D_, ("etaj" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.eta(), weight);
+            SafeHistFill(histMap1D_, ("phij" + std::to_string(i)).c_str(),
+                         channel_, variation.first, jet.phi(), weight);
+        }
     }
 }
 

--- a/src/ZZGenSelector.cc
+++ b/src/ZZGenSelector.cc
@@ -1,53 +1,30 @@
 #include "Analysis/VVAnalysis/interface/ZZGenSelector.h"
-#include "TLorentzVector.h"
 #include <boost/algorithm/string.hpp>
+#include "TLorentzVector.h"
 
-void ZZGenSelector::Init(TTree *tree)
-{
-    allChannels_ = {{ee, "ee"}, {mm, "mm"}, };
+void ZZGenSelector::Init(TTree *tree) {
+    allChannels_ = {
+        {ee, "ee"},
+        {mm, "mm"},
+    };
     hists1D_ = {
-        "GenZ2lep2_Phi",
-        "GenZ2lep2_Pt",
-        "GenMass",
-        "Pt",
-        "nJets",
-        "nJetCSVv2T",
-        "Genyield",
-        "GenZMass",
-        "GenZ1Mass",
-        "GenZ2Mass",
-        "GenZZPt",
-        "GenZZEta",
-        "GenZ1Pt",
-        "GenZ2Pt",
-        "GenZPt",
-        "GenZ1Phi",
-        "GenZ2Phi",
-        "GendPhiZ1Z2",
-        "GenLepPt",
-        "GenLepEta",
-        "GenLep12Pt",
-        "GenLep12Eta",
-        "GenLep34Pt",
-        "GenLep34Eta",
-        "GenZ1lep1_Eta",
-        "GenZ1lep1_Phi",
-        "GenZ1lep1_Pt",
-        "GenZ1lep2_Eta",
-        "GenZ1lep2_Phi",
-        "GenZ1lep2_Pt",
-        "GenZ2lep1_Eta",
-        "GenZ2lep1_Phi",
-        "GenZ2lep1_Pt",
-        "GenZ2lep2_Eta",
+        "GenZ2lep2_Phi", "GenZ2lep2_Pt",  "GenMass",       "Pt",
+        "nJets",         "nJetCSVv2T",    "Genyield",      "GenZMass",
+        "GenZ1Mass",     "GenZ2Mass",     "GenZZPt",       "GenZZEta",
+        "GenZ1Pt",       "GenZ2Pt",       "GenZPt",        "GenZ1Phi",
+        "GenZ2Phi",      "GendPhiZ1Z2",   "GenLepPt",      "GenLepEta",
+        "GenLep12Pt",    "GenLep12Eta",   "GenLep34Pt",    "GenLep34Eta",
+        "GenZ1lep1_Eta", "GenZ1lep1_Phi", "GenZ1lep1_Pt",  "GenZ1lep2_Eta",
+        "GenZ1lep2_Phi", "GenZ1lep2_Pt",  "GenZ2lep1_Eta", "GenZ2lep1_Phi",
+        "GenZ2lep1_Pt",  "GenZ2lep2_Eta",
     };
 
-    //hists2D_ = {"GenZ1Mass_GenZ2Mass"};
+    // hists2D_ = {"GenZ1Mass_GenZ2Mass"};
     SelectorBase::Init(tree);
 }
 
-
-void ZZGenSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void ZZGenSelector::LoadBranchesUWVV(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     Genweight = 1;
     b_Genl1Pt->GetEntry(entry);
     b_Genl2Pt->GetEntry(entry);
@@ -58,47 +35,45 @@ void ZZGenSelector::LoadBranchesUWVV(Long64_t entry, std::pair<Systematic, std::
     b_Genl1Phi->GetEntry(entry);
     b_Genl2Phi->GetEntry(entry);
     b_Genl3Phi->GetEntry(entry);
-    //std::cout<<"Is the ZZGenSelectorBase fine until here"<<std::endl;
-    if (channel_ == eeee || channel_ == eemm || channel_ == mmee || channel_ == mmmm) {
-      b_Genl4Pt->GetEntry(entry);
-      b_Genl4Eta->GetEntry(entry);
-      b_Genl4Phi->GetEntry(entry);
-      b_GenZ2mass->GetEntry(entry);
-      b_GenZ2pt->GetEntry(entry);
-      b_GenZ2Phi->GetEntry(entry);
+    // std::cout<<"Is the ZZGenSelectorBase fine until here"<<std::endl;
+    if (channel_ == eeee || channel_ == eemm || channel_ == mmee ||
+        channel_ == mmmm) {
+        b_Genl4Pt->GetEntry(entry);
+        b_Genl4Eta->GetEntry(entry);
+        b_Genl4Phi->GetEntry(entry);
+        b_GenZ2mass->GetEntry(entry);
+        b_GenZ2pt->GetEntry(entry);
+        b_GenZ2Phi->GetEntry(entry);
     }
     b_GenZ1mass->GetEntry(entry);
     b_GenZ1pt->GetEntry(entry);
     b_GenZ1Phi->GetEntry(entry);
-    if(channel_ == mmee) {
-      if(e1e2IsZ1())
-        Genweight=0.0;
-        //Makes Genweight 0 if Z1 is ee hence should not go in _mmee histos
+    if (channel_ == mmee) {
+        if (e1e2IsZ1()) Genweight = 0.0;
+        // Makes Genweight 0 if Z1 is ee hence should not go in _mmee histos
+    } else if (channel_ == eemm) {
+        if (!(e1e2IsZ1())) Genweight = 0.0;
+        // Makes Genweight 0 if Z1 is mm hence should not go in _eemm
     }
-    else if(channel_ == eemm) {
-      if(!(e1e2IsZ1()))
-        Genweight=0.0;
-        //Makes Genweight 0 if Z1 is mm hence should not go in _eemm 
-    } 
     b_GenMass->GetEntry(entry);
     b_GenPt->GetEntry(entry);
     b_GenEta->GetEntry(entry);
-    //std::cout<<"channel in LoadBranches function: "<<channel_<<std::endl;
-    if(channel_ == eemm || channel_ == mmee){
-      SetVariables(entry);
-    } 
+    // std::cout<<"channel in LoadBranches function: "<<channel_<<std::endl;
+    if (channel_ == eemm || channel_ == mmee) {
+        SetVariables(entry);
+    }
     auto deltaPhiZZ = [](float phi1, float phi2) {
-      float pi = TMath::Pi();
-      float dphi = std::abs(phi1-phi2);
-      if(dphi>pi)
-          dphi = 2.0*pi - dphi;
-      return dphi;
+        float pi = TMath::Pi();
+        float dphi = std::abs(phi1 - phi2);
+        if (dphi > pi) dphi = 2.0 * pi - dphi;
+        return dphi;
     };
 
-    GendPhiZZ = deltaPhiZZ(GenZ1Phi,GenZ2Phi);
+    GendPhiZZ = deltaPhiZZ(GenZ1Phi, GenZ2Phi);
 }
 
-void ZZGenSelector::LoadBranchesNanoAOD(Long64_t entry, std::pair<Systematic, std::string> variation) {
+void ZZGenSelector::LoadBranchesNanoAOD(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
     throw std::domain_error("NanoAOD ntuples not supported for ZZGenSelector!");
 }
 
@@ -108,7 +83,7 @@ void ZZGenSelector::SetBranchesNanoAOD() {
 
 void ZZGenSelector::SetBranchesUWVV() {
     if (channel_ == eeee) {
-        //std::cout<<"enum channel_: "<<channel_<<std::endl;
+        // std::cout<<"enum channel_: "<<channel_<<std::endl;
         fChain->SetBranchAddress("e1_e2_Mass", &GenZ1mass, &b_GenZ1mass);
         fChain->SetBranchAddress("e3_e4_Mass", &GenZ2mass, &b_GenZ2mass);
         fChain->SetBranchAddress("e1_e2_Pt", &GenZ1pt, &b_GenZ1pt);
@@ -128,8 +103,9 @@ void ZZGenSelector::SetBranchesUWVV() {
         fChain->SetBranchAddress("e3Phi", &Genl3Phi, &b_Genl3Phi);
         fChain->SetBranchAddress("e4Phi", &Genl4Phi, &b_Genl4Phi);
     }
-    //Add 2e2mu channel also but it still needs to differentiate which one is Z1Mass and which one is Z2Mass leptons
-    //This is done with a flag at the time of Process for each event on the fly
+    // Add 2e2mu channel also but it still needs to differentiate which one is
+    // Z1Mass and which one is Z2Mass leptons This is done with a flag at the
+    // time of Process for each event on the fly
     else if (channel_ == eemm) {
         fChain->SetBranchAddress("e1_e2_Mass", &GenZ1mass, &b_GenZ1mass);
         fChain->SetBranchAddress("m1_m2_Mass", &GenZ2mass, &b_GenZ2mass);
@@ -149,8 +125,7 @@ void ZZGenSelector::SetBranchesUWVV() {
         fChain->SetBranchAddress("e2Phi", &Genl2Phi, &b_Genl2Phi);
         fChain->SetBranchAddress("m1Phi", &Genl3Phi, &b_Genl3Phi);
         fChain->SetBranchAddress("m2Phi", &Genl4Phi, &b_Genl4Phi);
-    }
-    else if (channel_ == mmee) {
+    } else if (channel_ == mmee) {
         fChain->SetBranchAddress("e1_e2_Mass", &GenZ1mass, &b_GenZ1mass);
         fChain->SetBranchAddress("m1_m2_Mass", &GenZ2mass, &b_GenZ2mass);
         fChain->SetBranchAddress("e1_e2_Pt", &GenZ1pt, &b_GenZ1pt);
@@ -169,8 +144,7 @@ void ZZGenSelector::SetBranchesUWVV() {
         fChain->SetBranchAddress("e2Phi", &Genl2Phi, &b_Genl2Phi);
         fChain->SetBranchAddress("m1Phi", &Genl3Phi, &b_Genl3Phi);
         fChain->SetBranchAddress("m2Phi", &Genl4Phi, &b_Genl4Phi);
-    }
-    else if (channel_ == mmmm) {
+    } else if (channel_ == mmmm) {
         fChain->SetBranchAddress("m1_m2_Mass", &GenZ1mass, &b_GenZ1mass);
         fChain->SetBranchAddress("m3_m4_Mass", &GenZ2mass, &b_GenZ2mass);
         fChain->SetBranchAddress("m1_m2_Pt", &GenZ1pt, &b_GenZ1pt);
@@ -189,8 +163,7 @@ void ZZGenSelector::SetBranchesUWVV() {
         fChain->SetBranchAddress("m2Phi", &Genl2Phi, &b_Genl2Phi);
         fChain->SetBranchAddress("m3Phi", &Genl3Phi, &b_Genl3Phi);
         fChain->SetBranchAddress("m4Phi", &Genl4Phi, &b_Genl4Phi);
-    }
-    else
+    } else
         throw std::invalid_argument("Invalid channel choice!");
 
     fChain->SetBranchAddress("Mass", &GenMass, &b_GenMass);
@@ -199,40 +172,41 @@ void ZZGenSelector::SetBranchesUWVV() {
 }
 
 void ZZGenSelector::SetVariables(Long64_t entry) {
-    if(!(e1e2IsZ1())){
-      float tempMass = GenZ1mass;
-      GenZ1mass = GenZ2mass;
-      GenZ2mass = tempMass;
-      float tempPt = GenZ1pt;
-      GenZ1pt = GenZ2pt;
-      GenZ2pt = tempPt;
-      float templ1Pt = Genl1Pt;
-      Genl1Pt = Genl3Pt;
-      Genl3Pt = templ1Pt;
-      float templ2Pt = Genl2Pt;
-      Genl2Pt = Genl4Pt;
-      Genl4Pt = templ2Pt;
-      float templ1Eta = Genl1Eta;
-      Genl1Eta = Genl3Eta;
-      Genl3Eta = templ1Eta;
-      float templ2Eta = Genl2Eta;
-      Genl2Eta = Genl4Eta;
-      Genl4Eta = templ2Eta;
-      float templ1Phi = Genl1Phi;
-      Genl1Phi = Genl3Phi;
-      Genl3Phi = templ1Phi;
-      float templ2Phi = Genl2Phi;
-      Genl2Phi = Genl4Phi;
-      Genl4Phi = templ2Phi;
+    if (!(e1e2IsZ1())) {
+        float tempMass = GenZ1mass;
+        GenZ1mass = GenZ2mass;
+        GenZ2mass = tempMass;
+        float tempPt = GenZ1pt;
+        GenZ1pt = GenZ2pt;
+        GenZ2pt = tempPt;
+        float templ1Pt = Genl1Pt;
+        Genl1Pt = Genl3Pt;
+        Genl3Pt = templ1Pt;
+        float templ2Pt = Genl2Pt;
+        Genl2Pt = Genl4Pt;
+        Genl4Pt = templ2Pt;
+        float templ1Eta = Genl1Eta;
+        Genl1Eta = Genl3Eta;
+        Genl3Eta = templ1Eta;
+        float templ2Eta = Genl2Eta;
+        Genl2Eta = Genl4Eta;
+        Genl4Eta = templ2Eta;
+        float templ1Phi = Genl1Phi;
+        Genl1Phi = Genl3Phi;
+        Genl3Phi = templ1Phi;
+        float templ2Phi = Genl2Phi;
+        Genl2Phi = Genl4Phi;
+        Genl4Phi = templ2Phi;
     }
 }
 bool ZZGenSelector::ZZSelection() {
-    if ((GenZ1mass > 60.0 && GenZ1mass < 120.0) && (GenZ2mass > 60.0 && GenZ2mass < 120.0))
+    if ((GenZ1mass > 60.0 && GenZ1mass < 120.0) &&
+        (GenZ2mass > 60.0 && GenZ2mass < 120.0))
         return true;
     else
         return false;
 }
-//We already require 4 < Z1,Z2 < 120  in the "Loose Skim"
+// We already require 4 < Z1,Z2 < 120  in the "Loose Skim"
 bool ZZGenSelector::ZSelection() {
     if (GenZ1mass > 40.0 && GenZ2mass > 12.0)
         return true;
@@ -246,61 +220,104 @@ bool ZZGenSelector::Z4lSelection() {
         return false;
 }
 
-bool ZZGenSelector::e1e2IsZ1(){
-  return (std::abs(GenZ1mass-91.1876) < std::abs(GenZ2mass-91.1876));
+bool ZZGenSelector::e1e2IsZ1() {
+    return (std::abs(GenZ1mass - 91.1876) < std::abs(GenZ2mass - 91.1876));
 }
 
-void ZZGenSelector::FillHistograms(Long64_t entry, std::pair<Systematic, std::string> variation) { 
-    if (!ZZSelection())
-        return;
-    SafeHistFill(histMap1D_, "Genyield", channel_, variation.first, 1, Genweight);
-    SafeHistFill(histMap1D_, "GenMass", channel_, variation.first, GenMass,Genweight);
-    SafeHistFill(histMap1D_, "GenZMass", channel_, variation.first, GenZ1mass, Genweight);
-    SafeHistFill(histMap1D_, "GenZMass", channel_, variation.first, GenZ2mass, Genweight);
-    //Making LeptonPt and Eta plots
-    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl1Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl2Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl3Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl4Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl1Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl2Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl3Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl4Eta, Genweight);
+void ZZGenSelector::FillHistograms(
+    Long64_t entry, std::pair<Systematic, std::string> variation) {
+    if (!ZZSelection()) return;
+    SafeHistFill(histMap1D_, "Genyield", channel_, variation.first, 1,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenMass", channel_, variation.first, GenMass,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZMass", channel_, variation.first, GenZ1mass,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZMass", channel_, variation.first, GenZ2mass,
+                 Genweight);
+    // Making LeptonPt and Eta plots
+    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl1Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl2Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl3Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepPt", channel_, variation.first, Genl4Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl1Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl2Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl3Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLepEta", channel_, variation.first, Genl4Eta,
+                 Genweight);
     // Summing 12,34 leptons
-    SafeHistFill(histMap1D_, "GenLep12Pt", channel_, variation.first, Genl1Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLep12Pt", channel_, variation.first, Genl2Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLep34Pt", channel_, variation.first, Genl3Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLep34Pt", channel_, variation.first, Genl4Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenLep12Eta", channel_, variation.first, Genl1Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLep12Eta", channel_, variation.first, Genl2Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLep34Eta", channel_, variation.first, Genl3Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenLep34Eta", channel_, variation.first, Genl4Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1Mass", channel_, variation.first, GenZ1mass, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2Mass", channel_, variation.first, GenZ2mass, Genweight);
-    SafeHistFill(histMap1D_, "GenZPt", channel_, variation.first, GenZ1pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZPt", channel_, variation.first, GenZ2pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1Pt", channel_, variation.first, GenZ1pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2Pt", channel_, variation.first, GenZ2pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZZPt", channel_, variation.first, GenPt, Genweight);
-    SafeHistFill(histMap1D_, "GenZZEta", channel_, variation.first, GenEta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1Phi", channel_, variation.first, GenZ1Phi, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2Phi", channel_, variation.first, GenZ2Phi, Genweight);
-    SafeHistFill(histMap1D_, "GendPhiZ1Z2", channel_, variation.first, GendPhiZZ, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep1_Pt", channel_, variation.first, Genl1Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep1_Eta", channel_, variation.first, Genl1Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep1_Phi", channel_, variation.first, Genl1Phi, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep2_Pt", channel_, variation.first, Genl2Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep2_Eta", channel_, variation.first, Genl2Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ1lep2_Phi", channel_, variation.first, Genl2Phi, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep1_Pt", channel_, variation.first, Genl3Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep1_Eta", channel_, variation.first, Genl3Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep1_Phi", channel_, variation.first, Genl3Phi, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep2_Pt", channel_, variation.first, Genl4Pt, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep2_Eta", channel_, variation.first, Genl4Eta, Genweight);
-    SafeHistFill(histMap1D_, "GenZ2lep2_Phi", channel_, variation.first, Genl4Phi, Genweight);
-    //2D Z1 vs Z2
-    //SafeHistFill(hists2D_, "GenZ1Mass_GenZ2Mass", channel_, variation.first,GenZ1mass,GenZ2mass,Genweight);
-
+    SafeHistFill(histMap1D_, "GenLep12Pt", channel_, variation.first, Genl1Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep12Pt", channel_, variation.first, Genl2Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep34Pt", channel_, variation.first, Genl3Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep34Pt", channel_, variation.first, Genl4Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep12Eta", channel_, variation.first, Genl1Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep12Eta", channel_, variation.first, Genl2Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep34Eta", channel_, variation.first, Genl3Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenLep34Eta", channel_, variation.first, Genl4Eta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ1Mass", channel_, variation.first, GenZ1mass,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ2Mass", channel_, variation.first, GenZ2mass,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZPt", channel_, variation.first, GenZ1pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZPt", channel_, variation.first, GenZ2pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ1Pt", channel_, variation.first, GenZ1pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ2Pt", channel_, variation.first, GenZ2pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZZPt", channel_, variation.first, GenPt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZZEta", channel_, variation.first, GenEta,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ1Phi", channel_, variation.first, GenZ1Phi,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ2Phi", channel_, variation.first, GenZ2Phi,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GendPhiZ1Z2", channel_, variation.first,
+                 GendPhiZZ, Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep1_Pt", channel_, variation.first, Genl1Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep1_Eta", channel_, variation.first,
+                 Genl1Eta, Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep1_Phi", channel_, variation.first,
+                 Genl1Phi, Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep2_Pt", channel_, variation.first, Genl2Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep2_Eta", channel_, variation.first,
+                 Genl2Eta, Genweight);
+    SafeHistFill(histMap1D_, "GenZ1lep2_Phi", channel_, variation.first,
+                 Genl2Phi, Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep1_Pt", channel_, variation.first, Genl3Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep1_Eta", channel_, variation.first,
+                 Genl3Eta, Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep1_Phi", channel_, variation.first,
+                 Genl3Phi, Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep2_Pt", channel_, variation.first, Genl4Pt,
+                 Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep2_Eta", channel_, variation.first,
+                 Genl4Eta, Genweight);
+    SafeHistFill(histMap1D_, "GenZ2lep2_Phi", channel_, variation.first,
+                 Genl4Phi, Genweight);
+    // 2D Z1 vs Z2
+    // SafeHistFill(hists2D_, "GenZ1Mass_GenZ2Mass", channel_,
+    // variation.first,GenZ1mass,GenZ2mass,Genweight);
 }
 
 void ZZGenSelector::SetupNewDirectory() {

--- a/src/classes.h
+++ b/src/classes.h
@@ -1,46 +1,45 @@
+#include "Analysis/VVAnalysis/interface/Efficiency.h"
 #include "Analysis/VVAnalysis/interface/FakeRateSelector.h"
-#include "Analysis/VVAnalysis/interface/SelectorBase.h"
-#include "Analysis/VVAnalysis/interface/ZSelector.h"
 #include "Analysis/VVAnalysis/interface/LowPileupSelector.h"
-#include "Analysis/VVAnalysis/interface/LowPileupZSelector.h"
-#include "Analysis/VVAnalysis/interface/LowPileupWSelector.h"
 #include "Analysis/VVAnalysis/interface/LowPileupWBackgroundSelector.h"
-#include "Analysis/VVAnalysis/interface/ZZGenSelector.h"
-#include "Analysis/VVAnalysis/interface/WGenSelector.h"
-#include "Analysis/VVAnalysis/interface/ZGenSelector.h"
+#include "Analysis/VVAnalysis/interface/LowPileupWSelector.h"
+#include "Analysis/VVAnalysis/interface/LowPileupZSelector.h"
 #include "Analysis/VVAnalysis/interface/NanoGenSelectorBase.h"
-#include "Analysis/VVAnalysis/interface/WZSelector.h"
+#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/SelectorBase.h"
 #include "Analysis/VVAnalysis/interface/TTTSelector.h"
 #include "Analysis/VVAnalysis/interface/ThreeLepSelector.h"
-#include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
+#include "Analysis/VVAnalysis/interface/WGenSelector.h"
 #include "Analysis/VVAnalysis/interface/WZBackgroundSelector.h"
-#include "Analysis/VVAnalysis/interface/ScaleFactor.h"
+#include "Analysis/VVAnalysis/interface/WZSelector.h"
+#include "Analysis/VVAnalysis/interface/WZSelectorBase.h"
+#include "Analysis/VVAnalysis/interface/ZGenSelector.h"
+#include "Analysis/VVAnalysis/interface/ZSelector.h"
+#include "Analysis/VVAnalysis/interface/ZZGenSelector.h"
 #include "Analysis/VVAnalysis/interface/disambiguateFinalStates.h"
 #include "Analysis/VVAnalysis/interface/disambiguateFinalStatesZZ.h"
-#include "Analysis/VVAnalysis/interface/Efficiency.h"
 
-
-namespace{
-  namespace{
-    FakeRateSelector pFakeRateSelector;
-    WZSelectorBase pWZSelectorBase;
-    SelectorBase pSelectorBase;
-    ZSelector pZSelector;
-    LowPileupZSelector pLowPileupZSelector;
-    LowPileupWSelector pLowPileupWSelector;
-    LowPileupWSelector pLowPileupWBackgroundSelector;
-    LowPileupSelector pLowPileupSelector;
-    WZSelector pWZSelector;
-    NanoGenSelectorBase pNanoGenSelectorBase;
-    ZZGenSelector pZZGenSelector;
-    TTTSelector pTTTSelector;
-    ThreeLepSelector pThreeLepSelector;
-    WGenSelector pWGenSelector;
-    ZGenSelector pZGenSelector;
-    WZBackgroundSelector pWZBackgroundSelector;
-    ScaleFactor pScaleFactor;
-    disambiguateFinalStates pDisambiguator;
-    disambiguateFinalStates pDisambiguatorZZ;
-    Efficiency pEfficiency;
-  }
-}
+namespace {
+namespace {
+FakeRateSelector pFakeRateSelector;
+WZSelectorBase pWZSelectorBase;
+SelectorBase pSelectorBase;
+ZSelector pZSelector;
+LowPileupZSelector pLowPileupZSelector;
+LowPileupWSelector pLowPileupWSelector;
+LowPileupWSelector pLowPileupWBackgroundSelector;
+LowPileupSelector pLowPileupSelector;
+WZSelector pWZSelector;
+NanoGenSelectorBase pNanoGenSelectorBase;
+ZZGenSelector pZZGenSelector;
+TTTSelector pTTTSelector;
+ThreeLepSelector pThreeLepSelector;
+WGenSelector pWGenSelector;
+ZGenSelector pZGenSelector;
+WZBackgroundSelector pWZBackgroundSelector;
+ScaleFactor pScaleFactor;
+disambiguateFinalStates pDisambiguator;
+disambiguateFinalStates pDisambiguatorZZ;
+Efficiency pEfficiency;
+}  // namespace
+}  // namespace

--- a/src/disambiguateFinalStates.cc
+++ b/src/disambiguateFinalStates.cc
@@ -9,95 +9,83 @@
  */
 #include "Analysis/VVAnalysis/interface/disambiguateFinalStates.h"
 
-void disambiguateFinalStates::Init(TTree *tree)
-{
-  if (!tree) return;
-  fChain = tree;
+void disambiguateFinalStates::Init(TTree *tree) {
+    if (!tree) return;
+    fChain = tree;
 
-  fChain->SetBranchAddress(zCand_name, &Mass, &b_Mass);
-  fChain->SetBranchAddress("evt", &evt, &b_evt);
-  fChain->SetBranchAddress("run", &run, &b_run);
+    fChain->SetBranchAddress(zCand_name, &Mass, &b_Mass);
+    fChain->SetBranchAddress("evt", &evt, &b_evt);
+    fChain->SetBranchAddress("run", &run, &b_run);
 
-  SafeDelete(fCutFormula);
-  fCutFormula = new TTreeFormula("CutFormula", fOption, fChain);
-  fCutFormula->SetQuickLoad(kTRUE);
-  if (!fCutFormula->GetNdim()) { delete fCutFormula; fCutFormula = 0; }
-}
-
-Bool_t disambiguateFinalStates::Notify()
-{
-  return kTRUE;
-}
-
-void disambiguateFinalStates::Begin(TTree * /*tree*/)
-{
-}
-
-void disambiguateFinalStates::SlaveBegin(TTree * /*tree*/)
-{
-  fBestCandidateEntryList = new TEntryList("bestCandidates", "Entry List of disambiguated combinatoric candidates");
-  fOutput->Add(fBestCandidateEntryList);
-}
-
-Bool_t disambiguateFinalStates::Process(Long64_t entry)
-{
-  b_evt->GetEntry(entry);
-  b_run->GetEntry(entry);
-
-  if ( !(run == fCurrentRun && evt == fCurrentEvt) )
-  {
-    findBestEntry();
-  }
-
-  fCurrentRun = run;
-  fCurrentEvt = evt;
-  
-  // TODO Understand why this gives segfault for chains
-  // with multiple entries
-  if ( fCutFormula && fCutFormula->EvalInstance() > 0. )
-  {
-    b_Mass->GetEntry(entry);
-    Float_t discriminant = fabs(Mass-91.1876);
-    fEntriesToCompare.push_back(entry);
-    fEntryDiscriminants.push_back(discriminant);
-  }
-
-  if ( entry == fChain->GetEntries()-1 ) {
-    findBestEntry();
-  }
-
-  return kTRUE;
-}
-
-void disambiguateFinalStates::SlaveTerminate()
-{
-  fBestCandidateEntryList->OptimizeStorage();
-  // Pointer is owned by fOutput, dereference
-  fBestCandidateEntryList = nullptr;
-}
-
-void disambiguateFinalStates::Terminate()
-{
-}
-
-void disambiguateFinalStates::findBestEntry()
-{
-  Long64_t bestEntry = -1L;
-  Float_t lowestDiscriminant = 1e100;
-  for (size_t i=0; i<fEntriesToCompare.size(); ++i)
-  {
-    if ( lowestDiscriminant > fEntryDiscriminants[i] )
-    {
-      lowestDiscriminant = fEntryDiscriminants[i];
-      bestEntry = fEntriesToCompare[i];
+    SafeDelete(fCutFormula);
+    fCutFormula = new TTreeFormula("CutFormula", fOption, fChain);
+    fCutFormula->SetQuickLoad(kTRUE);
+    if (!fCutFormula->GetNdim()) {
+        delete fCutFormula;
+        fCutFormula = 0;
     }
-  }
+}
 
-  if ( bestEntry >= 0 )
-  {
-    fBestCandidateEntryList->Enter(bestEntry);
-  }
+Bool_t disambiguateFinalStates::Notify() { return kTRUE; }
 
-  fEntriesToCompare.clear();
-  fEntryDiscriminants.clear();
+void disambiguateFinalStates::Begin(TTree * /*tree*/) {}
+
+void disambiguateFinalStates::SlaveBegin(TTree * /*tree*/) {
+    fBestCandidateEntryList =
+        new TEntryList("bestCandidates",
+                       "Entry List of disambiguated combinatoric candidates");
+    fOutput->Add(fBestCandidateEntryList);
+}
+
+Bool_t disambiguateFinalStates::Process(Long64_t entry) {
+    b_evt->GetEntry(entry);
+    b_run->GetEntry(entry);
+
+    if (!(run == fCurrentRun && evt == fCurrentEvt)) {
+        findBestEntry();
+    }
+
+    fCurrentRun = run;
+    fCurrentEvt = evt;
+
+    // TODO Understand why this gives segfault for chains
+    // with multiple entries
+    if (fCutFormula && fCutFormula->EvalInstance() > 0.) {
+        b_Mass->GetEntry(entry);
+        Float_t discriminant = fabs(Mass - 91.1876);
+        fEntriesToCompare.push_back(entry);
+        fEntryDiscriminants.push_back(discriminant);
+    }
+
+    if (entry == fChain->GetEntries() - 1) {
+        findBestEntry();
+    }
+
+    return kTRUE;
+}
+
+void disambiguateFinalStates::SlaveTerminate() {
+    fBestCandidateEntryList->OptimizeStorage();
+    // Pointer is owned by fOutput, dereference
+    fBestCandidateEntryList = nullptr;
+}
+
+void disambiguateFinalStates::Terminate() {}
+
+void disambiguateFinalStates::findBestEntry() {
+    Long64_t bestEntry = -1L;
+    Float_t lowestDiscriminant = 1e100;
+    for (size_t i = 0; i < fEntriesToCompare.size(); ++i) {
+        if (lowestDiscriminant > fEntryDiscriminants[i]) {
+            lowestDiscriminant = fEntryDiscriminants[i];
+            bestEntry = fEntriesToCompare[i];
+        }
+    }
+
+    if (bestEntry >= 0) {
+        fBestCandidateEntryList->Enter(bestEntry);
+    }
+
+    fEntriesToCompare.clear();
+    fEntryDiscriminants.clear();
 }

--- a/src/disambiguateFinalStatesZZ.cc
+++ b/src/disambiguateFinalStatesZZ.cc
@@ -1,9 +1,9 @@
 /*
  * TSelector deduplicate events in combinatorical ntuple
  * by choosing event with l1_l2_Mass pairing closest to
- * M_PDG(Z) = 91.1876 
+ * M_PDG(Z) = 91.1876
  * with the highest scalar Pt sum of the remaining leptons
- * used as a tiebreaker. 
+ * used as a tiebreaker.
  *
  * Modified from K. Long, U. Wisconsin
  *
@@ -11,122 +11,114 @@
  */
 #include "Analysis/VVAnalysis/interface/disambiguateFinalStatesZZ.h"
 
-void disambiguateFinalStatesZZ::Init(TTree *tree)
-{
-  if (!tree) return;
-  fChain = tree;
+void disambiguateFinalStatesZZ::Init(TTree *tree) {
+    if (!tree) return;
+    fChain = tree;
 
-  fChain->SetBranchAddress(l1_l2_Cand_mass, &l1_l2_Mass, &b_l1_l2_Mass);
-  fChain->SetBranchAddress(l1_Cand_pt, &l1_Pt, &b_l1_Pt);
-  fChain->SetBranchAddress(l2_Cand_pt, &l2_Pt, &b_l2_Pt);
-  fChain->SetBranchAddress(l3_l4_Cand_mass, &l3_l4_Mass, &b_l3_l4_Mass);
-  fChain->SetBranchAddress(l3_Cand_pt, &l3_Pt, &b_l3_Pt); 
-  fChain->SetBranchAddress(l4_Cand_pt, &l4_Pt, &b_l4_Pt);
-  fChain->SetBranchAddress("evt", &evt, &b_evt);
-  fChain->SetBranchAddress("run", &run, &b_run);
+    fChain->SetBranchAddress(l1_l2_Cand_mass, &l1_l2_Mass, &b_l1_l2_Mass);
+    fChain->SetBranchAddress(l1_Cand_pt, &l1_Pt, &b_l1_Pt);
+    fChain->SetBranchAddress(l2_Cand_pt, &l2_Pt, &b_l2_Pt);
+    fChain->SetBranchAddress(l3_l4_Cand_mass, &l3_l4_Mass, &b_l3_l4_Mass);
+    fChain->SetBranchAddress(l3_Cand_pt, &l3_Pt, &b_l3_Pt);
+    fChain->SetBranchAddress(l4_Cand_pt, &l4_Pt, &b_l4_Pt);
+    fChain->SetBranchAddress("evt", &evt, &b_evt);
+    fChain->SetBranchAddress("run", &run, &b_run);
 
-  SafeDelete(fCutFormula);
-  fCutFormula = new TTreeFormula("CutFormula", fOption, fChain);
-  fCutFormula->SetQuickLoad(kTRUE);
-  if (!fCutFormula->GetNdim()) { delete fCutFormula; fCutFormula = 0; }
-}
-
-Bool_t disambiguateFinalStatesZZ::Notify()
-{
-  return kTRUE;
-}
-
-void disambiguateFinalStatesZZ::Begin(TTree * /*tree*/)
-{
-}
-
-void disambiguateFinalStatesZZ::SlaveBegin(TTree * /*tree*/)
-{
-  fBestCandidateEntryList = new TEntryList("bestCandidates", "Entry List of disambiguated combinatoric candidates");
-  fOutput->Add(fBestCandidateEntryList);
-}
-
-Bool_t disambiguateFinalStatesZZ::Process(Long64_t entry)
-{
-  b_evt->GetEntry(entry);
-  b_run->GetEntry(entry);
-
-  if ( !(run == fCurrentRun && evt == fCurrentEvt) )
-  {
-    findBestEntry();
-  }
-
-  fCurrentRun = run;
-  fCurrentEvt = evt;
-  
-  // TODO Understand why this gives segfault for chains
-  // with multiple entries
-  if ( fCutFormula && fCutFormula->EvalInstance() > 0. )
-    {
-    b_l1_l2_Mass->GetEntry(entry);
-    b_l1_Pt->GetEntry(entry);
-    b_l2_Pt->GetEntry(entry);
-    b_l3_l4_Mass->GetEntry(entry);
-    b_l3_Pt->GetEntry(entry); 
-    b_l4_Pt->GetEntry(entry);
-    
-    float mass_discriminant,Z2ptSum; 
-    //This condition identifies the Z1 candidate
-    //Required for the 2e2mu state but redundant for the 4e,4mu state however it should be quick comparison
-    if(fabs(l1_l2_Mass-91.1876) < fabs(l3_l4_Mass-91.1876)){
-      mass_discriminant = fabs(l1_l2_Mass-91.1876);
-      Z2ptSum = l3_Pt+l4_Pt;}
-    else{ 
-      mass_discriminant = fabs(l3_l4_Mass-91.1876);
-      Z2ptSum = l1_Pt+l2_Pt;}  
-    
-    fEntriesToCompare.push_back(entry);
-    fEntryDiscriminants.push_back(mass_discriminant);
-    fEntryZ2PtSum.push_back(Z2ptSum);
-  }
-
-  if ( entry == fChain->GetEntries()-1 ) {
-    findBestEntry();
-  }
-
-  return kTRUE;
-}
-
-void disambiguateFinalStatesZZ::SlaveTerminate()
-{
-  fBestCandidateEntryList->OptimizeStorage();
-  // Pointer is owned by fOutput, dereference
-  fBestCandidateEntryList = nullptr;
-}
-
-void disambiguateFinalStatesZZ::Terminate()
-{
-}
-
-void disambiguateFinalStatesZZ::findBestEntry()
-{
-  //The correct row is the one with Z1 closest
-  //to on-shell, with the highest scalar Pt sum of the remaining leptons
-  // used as a tiebreaker. 
-  Long64_t bestEntry = -1L;
-  float lowestDiscriminant = 1e100;
-  float MaxPtSum = 0.0;
-  for (size_t i=0; i<fEntriesToCompare.size(); ++i)
-  {
-    if ((fEntryDiscriminants[i] < lowestDiscriminant) || ((fEntryDiscriminants[i] == lowestDiscriminant) && (fEntryZ2PtSum[i] > MaxPtSum)))
-    {
-      MaxPtSum = fEntryZ2PtSum[i];
-      lowestDiscriminant = fEntryDiscriminants[i];
-      bestEntry = fEntriesToCompare[i];
+    SafeDelete(fCutFormula);
+    fCutFormula = new TTreeFormula("CutFormula", fOption, fChain);
+    fCutFormula->SetQuickLoad(kTRUE);
+    if (!fCutFormula->GetNdim()) {
+        delete fCutFormula;
+        fCutFormula = 0;
     }
-  }
+}
 
-  if ( bestEntry >= 0 )
-  {
-    fBestCandidateEntryList->Enter(bestEntry);
-  }
+Bool_t disambiguateFinalStatesZZ::Notify() { return kTRUE; }
 
-  fEntriesToCompare.clear();
-  fEntryDiscriminants.clear();
-  fEntryZ2PtSum.clear();
+void disambiguateFinalStatesZZ::Begin(TTree * /*tree*/) {}
+
+void disambiguateFinalStatesZZ::SlaveBegin(TTree * /*tree*/) {
+    fBestCandidateEntryList =
+        new TEntryList("bestCandidates",
+                       "Entry List of disambiguated combinatoric candidates");
+    fOutput->Add(fBestCandidateEntryList);
+}
+
+Bool_t disambiguateFinalStatesZZ::Process(Long64_t entry) {
+    b_evt->GetEntry(entry);
+    b_run->GetEntry(entry);
+
+    if (!(run == fCurrentRun && evt == fCurrentEvt)) {
+        findBestEntry();
+    }
+
+    fCurrentRun = run;
+    fCurrentEvt = evt;
+
+    // TODO Understand why this gives segfault for chains
+    // with multiple entries
+    if (fCutFormula && fCutFormula->EvalInstance() > 0.) {
+        b_l1_l2_Mass->GetEntry(entry);
+        b_l1_Pt->GetEntry(entry);
+        b_l2_Pt->GetEntry(entry);
+        b_l3_l4_Mass->GetEntry(entry);
+        b_l3_Pt->GetEntry(entry);
+        b_l4_Pt->GetEntry(entry);
+
+        float mass_discriminant, Z2ptSum;
+        // This condition identifies the Z1 candidate
+        // Required for the 2e2mu state but redundant for the 4e,4mu state
+        // however it should be quick comparison
+        if (fabs(l1_l2_Mass - 91.1876) < fabs(l3_l4_Mass - 91.1876)) {
+            mass_discriminant = fabs(l1_l2_Mass - 91.1876);
+            Z2ptSum = l3_Pt + l4_Pt;
+        } else {
+            mass_discriminant = fabs(l3_l4_Mass - 91.1876);
+            Z2ptSum = l1_Pt + l2_Pt;
+        }
+
+        fEntriesToCompare.push_back(entry);
+        fEntryDiscriminants.push_back(mass_discriminant);
+        fEntryZ2PtSum.push_back(Z2ptSum);
+    }
+
+    if (entry == fChain->GetEntries() - 1) {
+        findBestEntry();
+    }
+
+    return kTRUE;
+}
+
+void disambiguateFinalStatesZZ::SlaveTerminate() {
+    fBestCandidateEntryList->OptimizeStorage();
+    // Pointer is owned by fOutput, dereference
+    fBestCandidateEntryList = nullptr;
+}
+
+void disambiguateFinalStatesZZ::Terminate() {}
+
+void disambiguateFinalStatesZZ::findBestEntry() {
+    // The correct row is the one with Z1 closest
+    // to on-shell, with the highest scalar Pt sum of the remaining leptons
+    // used as a tiebreaker.
+    Long64_t bestEntry = -1L;
+    float lowestDiscriminant = 1e100;
+    float MaxPtSum = 0.0;
+    for (size_t i = 0; i < fEntriesToCompare.size(); ++i) {
+        if ((fEntryDiscriminants[i] < lowestDiscriminant) ||
+            ((fEntryDiscriminants[i] == lowestDiscriminant) &&
+             (fEntryZ2PtSum[i] > MaxPtSum))) {
+            MaxPtSum = fEntryZ2PtSum[i];
+            lowestDiscriminant = fEntryDiscriminants[i];
+            bestEntry = fEntriesToCompare[i];
+        }
+    }
+
+    if (bestEntry >= 0) {
+        fBestCandidateEntryList->Enter(bestEntry);
+    }
+
+    fEntriesToCompare.clear();
+    fEntryDiscriminants.clear();
+    fEntryZ2PtSum.clear();
 }


### PR DESCRIPTION
Ended up picking Google style but setting spaces for indent to 4. To format, you simply do

```
clang-format -i <file>
```
The `.clang-format` file holds are of the styling information. If we want to change the style to suit our preferences, its fairly easy, just pipe all c++ files into the clang-format command and there is plenty of documentation meaning finding these format options should in principle be easy.

If you see any style that looks glaringly bad, I can change and reformat